### PR TITLE
Svg arrows

### DIFF
--- a/contents_motif.svg
+++ b/contents_motif.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+   version="1.1" viewBox="0 0 24 24" height="24" width="24">
+  <path d="M12 4l8 8l-1.414 1.414L13 7.828V20h-2V7.828L5.414 13.414L4 12z"/>
+</svg>

--- a/cut.mli
+++ b/cut.mli
@@ -20,6 +20,7 @@ module type Config = sig
   val name_in : string
   val name_out : string
   val toc_style : toc_style
+  val svg_arrows: bool
   val cross_links : bool
   val small_length : int
 end

--- a/cut.mll
+++ b/cut.mll
@@ -23,6 +23,7 @@ module type Config = sig
   val name_in : string
   val name_out : string
   val toc_style : toc_style
+  val svg_arrows: bool
   val cross_links : bool
   val small_length : int
 end
@@ -81,9 +82,15 @@ let imgsrc img alt =
 
 
 let _ =
-  Hashtbl.add env "UPTXT" (imgsrc "contents_motif.gif" "Up") ;
-  Hashtbl.add env "PREVTXT" (imgsrc "previous_motif.gif" "Previous") ;
-  Hashtbl.add env "NEXTTXT" (imgsrc "next_motif.gif" "Next") ;
+ if Config.svg_arrows then begin
+   Hashtbl.add env "UPTXT" (imgsrc "contents_motif.svg" "Up") ;
+   Hashtbl.add env "PREVTXT" (imgsrc "previous_motif.svg" "Previous") ;
+   Hashtbl.add env "NEXTTXT" (imgsrc "next_motif.svg" "Next")
+ end else begin
+   Hashtbl.add env "UPTXT" (imgsrc "contents_motif.gif" "Up") ;
+   Hashtbl.add env "PREVTXT" (imgsrc "previous_motif.gif" "Previous") ;
+   Hashtbl.add env "NEXTTXT" (imgsrc "next_motif.gif" "Next")
+ end ;
   ()
 
 let get_env key =

--- a/hacha.ml
+++ b/hacha.ml
@@ -18,7 +18,7 @@ let filename = ref None
 let outname = ref "index.html"
 let log = ref false
 let toc_style = ref Cut.Normal
-let svg_arrows = ref false
+let svg_arrows = ref true
 let cross_links = ref true
 let verbose = ref 0
 let small_length = ref 1024
@@ -32,8 +32,8 @@ let main () =
        ", Duplicate table of contents at the begining of files");      
      ("-tocter", Arg.Unit (fun () -> toc_style := Cut.Special),
        ", Insert most of table of contents at the beginning of files");
-     ("-svg-arrows", Arg.Unit (fun () ->  svg_arrows := true ),
-       ", Use svg arrows for the previous/up/next links in generated pages");
+     ("-no-svg-arrows", Arg.Unit (fun () ->  svg_arrows := false ),
+       ", Use gif arrows for the previous/up/next links in generated pages");
      ("-nolinks", Arg.Unit (fun () -> cross_links := false),
        ", Suppress the prevous/up/next links in generated pages");
      ("-hrf", Arg.Unit (fun () -> log := true),

--- a/hacha.ml
+++ b/hacha.ml
@@ -18,6 +18,7 @@ let filename = ref None
 let outname = ref "index.html"
 let log = ref false
 let toc_style = ref Cut.Normal
+let svg_arrows = ref false
 let cross_links = ref true
 let verbose = ref 0
 let small_length = ref 1024
@@ -31,6 +32,8 @@ let main () =
        ", Duplicate table of contents at the begining of files");      
      ("-tocter", Arg.Unit (fun () -> toc_style := Cut.Special),
        ", Insert most of table of contents at the beginning of files");
+     ("-svg-arrows", Arg.Unit (fun () ->  svg_arrows := true ),
+       ", Use svg arrows for the previous/up/next links in generated pages");
      ("-nolinks", Arg.Unit (fun () -> cross_links := false),
        ", Suppress the prevous/up/next links in generated pages");
      ("-hrf", Arg.Unit (fun () -> log := true),
@@ -65,6 +68,7 @@ let main () =
     let name_in = filename
     let name_out = !outname
     let toc_style = !toc_style
+    let svg_arrows = !svg_arrows
     let cross_links = !cross_links 
     let small_length = !small_length
   end in
@@ -82,7 +86,12 @@ let main () =
   let some_links = C.do_lex buf in
   close_in chan ;
   if !log then Cross.dump (C.real_name (C.base^".hrf")) C.check_changed ;
-  if some_links then begin
+  if some_links && !svg_arrows then begin
+    Mysys.copy_from_lib_to_dir Mylib.libdir C.dir "previous_motif.svg" ;
+    Mysys.copy_from_lib_to_dir Mylib.libdir C.dir "next_motif.svg" ;
+    Mysys.copy_from_lib_to_dir Mylib.libdir C.dir "contents_motif.svg"
+  end
+  else if some_links then begin
     Mysys.copy_from_lib_to_dir Mylib.libdir C.dir "previous_motif.gif" ;  
     Mysys.copy_from_lib_to_dir Mylib.libdir C.dir "next_motif.gif" ;  
     Mysys.copy_from_lib_to_dir Mylib.libdir C.dir "contents_motif.gif"

--- a/install.sh
+++ b/install.sh
@@ -43,6 +43,7 @@ case $1 in
 esac
 
 install . $LIBDIR imagen xxcharset.exe xxdate.exe contents_motif.gif next_motif.gif previous_motif.gif $ALLLIB
+install . $LIBDIR contents_motif.svg next_motif.svg previous_motif.svg
 install . $LATEXLIBDIR hevea.sty mathjax.sty
 install html $LIBDIR/html $HTMLLIB
 install text $LIBDIR/text $TEXTLIB

--- a/next_motif.svg
+++ b/next_motif.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+  version="1.1" viewBox="0 0 24 24" height="24" width="24" >
+  <path d="M20 12l-8 8l-1.414 -1.414L16.172 13H4v-2H16.172L10.586 5.414L12 4 z"/>
+</svg>

--- a/previous_motif.svg
+++ b/previous_motif.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+  version="1.1" viewBox="0 0 24 24" height="24" width="24" >
+  <path d="M4 12l8 8l1.414 -1.414L7.828 13H20v-2H7.828L13.414 5.414L12 4z"/>
+</svg>


### PR DESCRIPTION
This small PR adds three svg variants to the previous/up/next arrows used by hacha, and a corresponding command line flag `-svg-arrows`.  The svg arrows themselves are quite minimalist to go with the flat design trend.