### PR TITLE
Fix (not so) critical bug in README

### DIFF
--- a/README
+++ b/README
@@ -1,8 +1,7 @@
 This is HEVEA, version 2.32, a fast Latex to HTML translator.
 
 
-ADVERTISEMENT
-
+NOTE
     HEVEA is a LaTeX to HTML translator.  The input language is a fairly
     complete subset of LaTeX2e (old LaTeX style is also accepted) and the
     output language is HTML that is (hopefully) correct with respect to

--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 This is HEVEA, version 2.32, a fast Latex to HTML translator.
 
 
-NOTE
+ADVERTISEMENT
     HEVEA is a LaTeX to HTML translator.  The input language is a fairly
     complete subset of LaTeX2e (old LaTeX style is also accepted) and the
     output language is HTML that is (hopefully) correct with respect to
@@ -35,8 +35,6 @@ DOCUMENTATION
     http://hevea.inria.fr/doc/
 
 DISTRIBUTION
-    By FTP
-      ftp://ftp.inria.fr/INRIA/moscova/hevea/
     By HTTP
       http://hevea.inria.fr/distri/
 
@@ -124,7 +122,6 @@ MAKE
 
 
 IN CASE OF TROUBLE.
-
   - You do need version 3.12 (or newer) of the Objective Caml System.
     Older versions of Objective Caml cannot compile hevea.
 


### PR DESCRIPTION
Je suppose que l'auteur souhaitait dire "avertissement" en anglais, mais "advertisement" signifie "publicité".
Je propose de remplacer "advertisement" par "note", qui signifie "remarque".
Je propose aussi de supprimer la ligne vide sous "Note" pour devenir cohérent avec le reste du README (pas de ligne vide sous les sous-titres).