### PR TITLE
Reimplement the HTML handling of \marginpar

### DIFF
--- a/html/hevea.hva
+++ b/html/hevea.hva
@@ -99,6 +99,7 @@
 \newstyle{.footnotetext}{margin:0ex; padding:0ex;}
 \newstyle{div.footnotetext P}{margin:0px; text-indent:1em;}
 %Other styles
+\newstyle{body}{margin-left:20\%; margin-right:20\%;}
 \setenvclass{thefootnotes}{thefootnotes}
 \setenvclass{dt-thefootnotes}{dt-thefootnotes}
 \setenvclass{dd-thefootnotes}{dd-thefootnotes}
@@ -668,12 +669,9 @@
 {\@open{div}{class="\getenvclass{minipage}"}}
 {\@close{div}}
 %%%%%%%%margin par
-\newstyle{.marginpar}
-{border:solid thin black; width:20\%; text-align:left;}
-\newstyle{.marginparleft}
-  {float:left; margin-left:0ex; margin-right:1ex;}
-\newstyle{.marginparright}
-  {float:right; margin-left:1ex; margin-right:0ex;}
+\newstyle{.marginpar}{margin-bottom:1ex; width:18\%;}
+\newstyle{.marginparleft}{clear:left; float:left; margin-left:-22\%; margin-right:1em;}
+\newstyle{.marginparright}{clear:right; float:right; margin-left:1em; margin-right:-22\%;}
 \newif\ifmarginright\marginrighttrue
 \setenvclass{marginpar}{marginpar}
 \setenvclass{marginparside}{marginparright}
@@ -684,7 +682,9 @@
 \newcommand{\hva@mtemp}{}
 \newcommand{\marginpar}[2][]
 {\def\hva@mtemp{#1}%
-\@open{div}{class="\getenvclass{marginpar} \getenvclass{marginparside}"}%
+\push@styles
+\@clearstyle
+\@open{span}{class="\getenvclass{marginpar} \getenvclass{marginparside}"}%
 \ifx\hva@mtemp\@empty%
 #2%
 \else\ifmarginright
@@ -692,7 +692,8 @@
 \else
 #1%
 \fi\fi
-\@close{div}}
+\@close{span}
+\pop@styles}
 %%%%%%%%Default env class for verbatim
 \setenvclass{verbatim}{verbatim}
 %%%%%% format theorems


### PR DESCRIPTION
The old way to handle `\marginpar` in HTML is to insert `div`-elements that
tear apart paragraphs.  Moreover, the marginal text does not end up in the
margins but gets squeezed into a box at the side of the body text.

This P/R replaces the `div` with `span` and adjusts the CSS part to get an
HTML layout that is much closer to the LaTeX layout (at least of "article.cls").
(As is, the new `\marginpar`s can serve as a base for implementing marginal
notes (aka sidenotes) that completely replace `\footnote`s in a web page.)
