### PR TITLE
Implement macro \justifying and environment justify

### DIFF
--- a/ragged2e.hva
+++ b/ragged2e.hva
@@ -1,6 +1,10 @@
 \let\RaggedRight\raggedright
 \let\RaggedLeft\raggedleft
 \let\Centering\centering
+\newstyle{.justify}{text-align:justify;margin-left:auto;margin-right:auto;}
+\newcommand{\justifying}{\@insert{div}{\envclass@attr{justify}}}
 \newenvironment{Center}{\begin{center}}{\end{center}}
 \newenvironment{FlushLeft}{\begin{flushleft}}{\end{flushleft}}
 \newenvironment{FlushLeftRight}{\begin{flushright}}{\end{flushright}}
+\setenvclass{justify}{justify}
+\newenvironment{justify}{\@open{div}{\envclass@attr{justify}}}{\@close{div}}


### PR DESCRIPTION
LaTeX package ragged2e implements macro \justifying and environment justify
to switch back from its ragged-left and ragged-right modes.  This P/R implements
the same functionality for HTML with the help of `text-align`-mode `justify`.

BTW, to move Hevea's layout closer to LaTeX's _default_ `text-align: justify` can
to go into the CSS element for `body`.
