### PR TITLE
Introduce a novel type of block to implement \marginpar.

### DIFF
--- a/html.ml
+++ b/html.ml
@@ -317,7 +317,12 @@ let open_block_with_par ss s a =
   end ;
   open_block_loc s a
 
-let open_block ss a = open_block_with_par ss (find_block ss) a
+let open_block ?(force_inline=false) ss a =
+  let s = find_block ss in
+    if force_inline then
+      open_block_loc s a
+    else
+      open_block_with_par ss s a
 
 let open_display () =
   if find_prev_par () then begin

--- a/html/hevea.hva
+++ b/html/hevea.hva
@@ -668,12 +668,9 @@
 {\@open{div}{class="\getenvclass{minipage}"}}
 {\@close{div}}
 %%%%%%%%margin par
-\newstyle{.marginpar}
-{border:solid thin black; width:20\%; text-align:left;}
-\newstyle{.marginparleft}
-  {float:left; margin-left:0ex; margin-right:1ex;}
-\newstyle{.marginparright}
-  {float:right; margin-left:1ex; margin-right:0ex;}
+\newstyle{.marginpar}{border:solid thin black; margin-bottom:1ex; width:20\%; text-align:left;}
+\newstyle{.marginparleft}{float:left; clear:left; margin-left:0ex; margin-right:1ex;}
+\newstyle{.marginparright}{float:right; clear:right; margin-left:1ex; margin-right:0ex;}
 \newif\ifmarginright\marginrighttrue
 \setenvclass{marginpar}{marginpar}
 \setenvclass{marginparside}{marginparright}
@@ -684,7 +681,7 @@
 \newcommand{\hva@mtemp}{}
 \newcommand{\marginpar}[2][]
 {\def\hva@mtemp{#1}%
-\@open{div}{class="\getenvclass{marginpar} \getenvclass{marginparside}"}%
+\@open{span@inline@block}{class="\getenvclass{marginpar} \getenvclass{marginparside}"}%
 \ifx\hva@mtemp\@empty%
 #2%
 \else\ifmarginright
@@ -692,7 +689,7 @@
 \else
 #1%
 \fi\fi
-\@close{div}}
+\@close{span@inline@block}}
 %%%%%%%%Default env class for verbatim
 \setenvclass{verbatim}{verbatim}
 %%%%%% format theorems

--- a/latexscan.mll
+++ b/latexscan.mll
@@ -315,6 +315,8 @@ let top_open_block block args =
       push stack_display !display ;
       display := true ;
       Dest.open_display_varg args
+  | "span@inline@block" ->
+      Dest.open_block ~force_inline:true "span" args
   | "table" ->
       save_array_state () ;
       in_table := NoTable ;
@@ -344,6 +346,8 @@ and top_close_block_aux close_fun block =
   | "display" ->
       Dest.close_display () ;
       display := pop stack_display
+  | "span@inline@block" ->
+      close_fun "span"
   | "table" ->
       close_fun "table" ;
       top_force_item_display () ;

--- a/outManager.mli
+++ b/outManager.mli
@@ -27,7 +27,7 @@ val forget_par : unit -> int option
 val close_par : unit -> bool
 val open_par : unit -> unit
 val par : int option -> unit
-val open_block : string -> string -> unit
+val open_block : ?force_inline:bool -> string -> string -> unit
 val close_block : string -> unit
 val force_block : string -> string -> unit
 val close_flow : string -> unit

--- a/text.ml
+++ b/text.ml
@@ -851,7 +851,7 @@ let try_close_block s =
   flags.in_align <- ia
 ;;
 
-let open_block s arg =  
+let [@warning "-27"] open_block ?(force_inline=false) s arg =
   let s = tr_block s arg in
   (* Cree et se place dans le bloc de nom s et d'arguments args *)
   if !verbose > 2 then eprintf "=> open_block '%s'\n" (pp_block s);


### PR DESCRIPTION
Introduce a novel type of block: `span@inline@block`.
Its semantics are tailor made to meet the processing expectations of
`\marginpar`; implement Hevea's `\marginpar` with the help of
`span@inline@block`.

Slightly adjust the style of marginpars:
- Add a small bottom margin to prevent multiple borders from bumping
  into each other (margin-bottom:1ex).
- Instruct all marginpar-boxes to clear to the same side as the
  initial one (clear:left and clear:right).

Here is a small example that can be used to visualize the changes:

```latex
\documentclass{article}
\usepackage{hevea}
\begin{document}
aaaaaaaa bbbbbbbb
cccccccc dddddddd
eeeeeeee ffffffff
gggggggg hhhhhhhh
iiii\marginpar{IIII}iiii jjjj\marginpar{JJJJ}jjjj
kkkk\marginpar{KKKK}kkkk llll\marginpar{LLLL}llll
mmmmmmmm nnnnnnnn
oooooooo pppppppp
qqqqqqqq rrrrrrrr
ssssssss tttttttt
\end{document}
```

The old implementation rips the eight-groups of `i`, `j`, `k`, and `l`
apart.  With this P/R they stay intact as they should.

As the block type is highly specialized I have not added it to
the documentation.
