### PR TITLE
Introduce CSS-classes for font families and font variants.

### DIFF
--- a/doc/text.tex
+++ b/doc/text.tex
@@ -5832,66 +5832,63 @@ Section~\ref{getstylecolor:example} for an example.
 \section{Font Selection}
 
 \subsection{Changing the Type Style}\label{type-style}
-All \LaTeXe{} declarations and environments for changing type style
-are recognised. Aspect is rather like \LaTeXe{} output, but there is
-no guarantee.
+All \LaTeXe{} declarations and environments for changing the type
+style are recognised.  Visual appearance resembles that of \LaTeX's
+output, but there is no guarantee for far-reaching concordance.
 
-As \html{} does not provide the same variety of type styles as
-\LaTeX{} does.
-However \css{} provide a wide variety of font properties.
-\hevea{} uses generic properties, proper rendering will then depend
-upon user agent.
-For instance, it belongs to the user agent
-to make a difference between
-\textit{italics} (rendered by the font style ``italic'')
-and \textsl{slanted} (rendered by the font style ``oblique'').
+HTML does not offer the same repertory of type styles as \LaTeX{}
+does.  However, CSS provide a wide variety of font
+properties.  \hevea{} uses generic properties, proper rendering will
+then depend upon user agent.  For instance, it belongs to the user
+agent to make a difference between \textit{italics} (rendered by
+font~style ``italic'') and
+\textsl{slanted} (rendered by font~style ``oblique''), but also see
+Sec.~\ref{sec:italics-vs-slanted} below.
 
-Here is how \hevea{} implements text-style declarations by default:
+Here is a table that shows how \hevea{} implements text-style
+declarations.  See Sec.~\ref{sec:controlling-font-selection-with-css}
+for the default definitions of all CSS-classes.
+
 \begin{center}
-\newcommand{\heveastyle}[2]{{\ifhevea#1\fi#2}}
-\begin{tabular}{*{3}{p{.3\linewidth}}}
-\begin{tabular}{l@{\quad}l} \hline
-\verb+\itshape+ &  \heveastyle{\itshape}{font-style:italic}\\
-\verb+\slshape+ &  \heveastyle{\slshape}{font-style:oblique}\\
-\verb+\scshape+ &  \heveastyle{\scshape}{font-variant:small-caps}\\
-\verb+\upshape+ &  \heveastyle{\upshape}{no style}\\ \hline
-\end{tabular}
- &
-\begin{tabular}{l@{\quad}l} \hline
-\verb+\ttfamily+ & \heveastyle{\ttfamily}{font-family:monospace}\\
-\verb+\sffamily+ & \heveastyle{\sffamily}{font-family:sans-serif}\\
-\verb+\rmfamily+ &  \heveastyle{\rmfamily}{no style}\\ \hline
-\end{tabular}
-
-&
-\begin{tabular}{l@{\quad}l} \hline
-\verb+\bfseries+ & \heveastyle{\bfseries}{font-weight:bold}\\
-\verb+\mdseries+ & \heveastyle{\mdseries}{no style}\\ \hline
-\end{tabular}
+\newcommand{\samplephrase}{White Handgloves}
+\begin{tabular}{l@{\quad}l@{\quad}l@{\quad}l@{\quad}l@{\quad}l@{\quad}l}
+Axis      &  Name        &  Generator         &  \multicolumn{2}{c}{Macro}       &  Implementation                   &  Font-Sample  \\
+          &              &                    &  \LaTeXe          &  Old         &  ``Style-''Attribute              &  \\
+\hline
+Family    &  normal      &  \verb+\rmfamily+  &  \verb+\textrm+   &  \verb+\rm+  &  \verb+class: serif+              &  \textrm{\samplephrase}  \\
+          &  sans serif  &  \verb+\sffamily+  &  \verb+\textsf+   &  \verb+\sf+  &  \verb+class: sans-serif+         &  \textsf{\samplephrase}  \\
+          &  typewriter  &  \verb+\ttfamily+  &  \verb+\texttt+   &  \verb+\tt+  &  \verb+class: monospace+          &  \texttt{\samplephrase}  \\
+Variant   &  upright     &  \verb+\upshape+   &  \verb+\upshape+  &  \verb+\up+  &  \textit{no style}                &  \upshape{\samplephrase}  \\
+          &  italics     &  \verb+\itshape+   &  \verb+\textit+   &  \verb+\it+  &  \verb+class: italic+             &  \textit{\samplephrase}  \\
+          &  slanted     &  \verb+\slshape+   &  \verb+\textsl+   &  \verb+\sl+  &  \verb+class: slanted+            &  \textsl{\samplephrase}  \\
+          &  small caps  &  \verb+\scshape+   &  \verb+\textsc+   &  \verb+\sc+  &  \verb+class: smallcaps+          &  \textsc{\samplephrase}  \\
+          &  emphasized  &  \verb+\em+        &  \verb+\emph+     &  \verb+\em+  &  HTML-element ``em''              &  \emph{\samplephrase}  \\
+Weight    &  normal      &  \verb+\mdseries+  &  \verb+\textmd+   &  \verb+\md+  &  \textit{no style}                &  \mdseries{\samplephrase}  \\
+          &  bold        &  \verb+\bfseries+  &  \verb+\textbf+   &  \verb+\bf+  &  \verb+font-weight: bold+         &  \textbf{\samplephrase}  \\
 \end{tabular}
 \end{center}
 
 
-Text-style commands also exists, they are defined as
-\verb+\mbox{\+\textit{decl}\ldots\verb+}+. For instance,
-\verb+\texttt+ is defined as a command with one argument whose body is
-\verb+\mbox{\ttfamily#1}+.
-Finally, the \verb+\emph+ command for emphasised text also exists,
-it yields text-level \verb+em+ elements.
+Text-style commands exist as well; they are defined
+as \verb+\mbox{\+\textit{decl}\ldots\verb+}+.  For
+instance, \verb+\texttt+ is defined as a command with one argument
+whose body is \verb+\mbox{\ttfamily #1}+.  Finally,
+the \verb+\emph+~command for emphasised text also exists, it yields
+text-level \verb+em+~elements.
 
 
-As in \LaTeX{}, type styles consists in three components:
-\emph{shape}, \emph{series} and \emph{family}.
-\hevea{} implements the three components by making one declaration to
-cancel the effect of other declarations of the same kind.
+As in \LaTeX{}, type styles consist of three
+components: \emph{shape}, \emph{series} and \emph{family}.  \hevea{}
+implements the three components by making one declaration to cancel
+the effect of other declarations of the same kind.
 \begin{htmlonly}
 For instance consider the following source, that exhibits shape changes:
 \begin{verbatim}
 {\itshape italic shape \slshape slanted shape
 \scshape small caps shape \upshape upright shape}
 \end{verbatim}
-Then, in the rendering below, ``small caps shape'' appears in small caps shape
-only and not in italics:
+Then, in the rendering below, ``small caps shape'' appears in small
+caps shape only and not in italics:
 \begin{htmlout}
 {\itshape italic shape \slshape slanted shape
 \scshape small caps shape \upshape upright shape}
@@ -5900,28 +5897,355 @@ only and not in italics:
 
 
 Old style declarations are also recognised, they translate to
-text-level elements. However, no elements are cancelled when using
-old style declaration. Thus, the source
-``\verb+{\sl\sc slanted and small caps}+'' yields ``slanted''
-small caps\ifhevea: ``{\sl\sc slanted and small caps}''\fi.
-Users need probably not worry about this. However this has an
-important practical consequence: to change the default rendering of
-type styles, one should redefine old style declaration in order to
-benefit from the cancellation mechanism. See
+text-level elements.  However, no elements are cancelled when using
+old style declaration.  Thus, the source ``\verb+{\sl\sc slanted and
+small caps}+'' yields ``slanted'' small~caps\ifhevea: ``{\sl\sc
+slanted and small caps}''\fi.  Users do not need not worry about this,
+though it has an important practical consequence: to change the
+default rendering of type styles, one should redefine old style
+declaration in order to benefit from the cancellation mechanism.  See
 section~\ref{customize-style} for a more thorough description.
 
 
 \subsection{Changing the Type Size}
 All declarations, from \verb+\tiny+ to \verb+\Huge+ are recognised.
-Output is not satisfactory inside headers elements
-generated by sectioning commands.
+Output is not satisfactory inside header elements generated by
+sectioning commands.
 
 \subsection{Special Symbols}
+The \verb+\symbol{+\textit{num}\verb+}+ outputs character
+number~\textit{num} (decimal) from the Unicode character set.  This
+departs from \LaTeX{} which outputs symbol number~\textit{num} in the
+current font.
 
-The \verb+\symbol{+{\it num}\verb+}+ outputs character number {\it num}
-(decimal) from the Unicode character set.
-This departs from \LaTeX{}, which output symbol number \textit{num} in
-the current font.
+\subsection{\label{sec:controlling-font-selection-with-css}%
+  Controlling Font Selection with CSS}
+\hevea{} predefines CSS~classes that control the font selection of an
+HTML-document.
+
+\begin{center}
+\begin{tabular}{l@{\quad}l@{\quad}lp{.5\linewidth}}
+Class             &  Default                          &  Application  \\
+\hline
+\verb+serif+      &  \verb+font-family: serif+        &  Body text and math; used by \verb+\textrm+.  \\
+\verb+sansserif+  &  \verb+font-family: sans-serif+   &  Text tagged with \verb+\textsf+.  \\
+\verb+monospace+  &  \verb+font-family: monospace+    &  Any typewriter text and in particular environment~\verb+verbatim+, macros~\verb+\verb+, and \verb+\texttt+.  \\
+\verb+italic+     &  \verb+font-style: italic+        &  Text tagged with \verb+\textit+.  \\
+\verb+slanted+    &  \verb+font-style: oblique+       &  Text tagged with \verb+\textsl+.  \\
+\verb+smallcaps+  &  \verb+font-variant: small-caps+  &  Text tagged with \verb+\textsc+.  \\
+\end{tabular}
+\end{center}
+
+The defaults for classes \verb+serif+, \verb+sansserif+, and
+\verb+monospace+ are the browser's defaults, namely \verb+serif+,
+\verb+sans-serif+, and \verb+monospace+.  Users can simply override
+the classes in the document preamble.  Moreover, as these are
+CSS~classes \emph{all} properties apply.  Besides gaudy effects this
+comes in handy to adjust the base size of the typewriter font to match
+the body text, for example with
+
+\begin{verbatim}
+\newstyle{.monospace}{font-family: "Courier New", Courier, monospace; font-size: 120\%}
+\end{verbatim}
+
+\noindent or to fine-tune \verb+font-stretch+ and \verb+font-weight+.
+
+Despite their names the classes can host any font chosen from any
+family:
+
+\begin{verbatim}
+\newstyle{.serif}{font-family: Go, sans-serif}
+\newstyle{.sansserif}{font-family: Go, sans-serif}
+\newstyle{.monospace}{font-family: "Go Mono", monospace}
+\end{verbatim}
+
+Furthermore, the \verb+monospace+~class does not need to reference
+mono-spaced fonts, though proportional fonts probably will skew output
+that aligns for fonts with a fixed width.
+
+To achieve consistency in font selection it is constructive to define
+a macro for each family and then use these to set the document's font
+families as well as selected elements as, for example, the chapter and
+section headings.
+
+\begin{verbatim}
+\newcommand{\seriffontfamily}{"Noto Serif", serif}
+\newcommand{\sansfontfamily}{"Noto Sans", sans-serif}
+\newcommand{\fixedfontfamily}{"Noto Mono", monospace}
+
+\newstyle{.serif}{font-family: \seriffontfamily}
+\newstyle{.sansserif}{font-family: \sansfontfamily}
+\newstyle{.monospace}{font-family: \fixedfontfamily}
+
+\newstyle{.chapter, .section, .subsection, .subsubsection}{font-family: \sansfontfamily}
+\end{verbatim}
+
+\subsubsection{\label{sec:italics-vs-slanted}%
+  Italics vs.\ Slanted}
+
+\TeX{} serves separate fonts for italics and slanted characters in the
+same superfamily ``Latin Modern'', for example, ``Latin Modern Roman
+10~Italic'' and ``Latin Modern Roman Slanted 10~Regular''.  Needless
+to say all members in the superfamily are extremely well matched!  On
+the HTML-side it is hard to recreate this kind of super-pairing; most
+often a font family will \emph{lack} a ``slanted'' variant and --
+depending on the font-synthesis settings -- browsers substitute
+``italic''.  This means \verb+\textit+ and \verb+\textsl+ will be
+mapped to the \emph{same} font.
+
+To remedy this, \hevea{} supports two separate, dedicated CSS-classes
+for italics and slanted type, appropriately called \verb+italic+ and
+\verb+slanted+.  These can be overridden by users in concert with the
+three font-family classes~\verb+serif+, \verb+sansserif+, and
+\verb+monospace+ either to approximate the output of \LaTeX{} or to
+create enough of visual distinction (``contrast'') of \verb+italic+
+and \verb+slanted+ to convey the semantic differences of
+\verb+\textit+ and \verb+\textsl+.
+
+\begin{verbatim}
+\newstyle{.serif}{font-family: "FreeSerif", serif}
+\newstyle{.sansserif}{font-family: "FreeSans", sans-serif}
+\newstyle{.monospace}{font-family: "FreeMono", monospace}
+\newstyle{.slanted}{font-family: "Liberation Serif", "FreeSerif", serif; font-style: oblique}
+\end{verbatim}
+
+\noindent In the example above there is no need to redefine
+\verb+italic+ as the italics of \verb+FreeSerif+ and
+\verb+Liberation Serif+ are quite distinct.
+
+A complementary approach is to use the default italics for
+class~\verb+slanted+ and supply a different font family for
+\verb+italic+:
+
+\begin{verbatim}
+\newstyle{.serif}{font-family: "FreeSerif", serif}
+\newstyle{.sansserif}{font-family: "FreeSans", sans-serif}
+\newstyle{.monospace}{font-family: "FreeMono", monospace}
+\newstyle{.italic}{font-family: "Accanthis ADF Std No3", serif; font-style: italic}
+\newstyle{.slanted}{font-family: "FreeSerif", serif; font-style: oblique}
+\end{verbatim}
+
+\subsubsection{Dedicated Smallcaps}
+
+\hevea{} translates \verb+\textsc+ into CSS~class \verb+smallcaps+,
+which in turn activates \verb+font-variant: small-caps+ by default.
+This instructs the browser to look for small-capital letters in the
+\emph{currently selected font}, but no further.  Regrettably, only few
+fonts come with small~caps included (look for, e.g., ``Pro'' or
+``Expert'' series), for all others the browser synthesizes the glyphs
+based on the selected font.  See also
+\footahref{https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-caps}{font-variant-caps}.
+
+\paragraph{Separate Small-Caps Fonts.} What is more common today are
+regular fonts that pair with separate fonts that cover their
+small~caps.  Here are some representative examples:
+
+\begin{itemize}
+\item Cormorant -- Cormorant SC
+\item Go -- Go Smallcaps
+\item Latin Modern Roman -- Latin Modern Roman Caps
+\end{itemize}
+
+\noindent By overriding the default definition of
+CSS~class \verb+smallcaps+ these font pairings can be lifted
+into \hevea.
+
+\begin{verbatim}
+\newstyle{.serif}{font-family: "Berenis ADF Pro", serif}
+\newstyle{.smallcaps}{font-family: "Berenis ADF Pro SC", serif; font-variant: normal}
+\end{verbatim}
+
+It is important to set \verb+font-variant: normal+ with a small~caps
+font so that the default is overridden and font synthesis does
+\emph{not} kick in!  Otherwise the browser uses the uppercase letters
+of a resized variant of the small~caps font to synthesize the small
+caps, which defeats the very purpose of the class override and -- on
+top of that -- generally looks ugly.
+
+If you latch a non-smallcaps font, stick with the default as here
+glyph synthesis in fact is desired.
+
+\begin{verbatim}
+\newstyle{.smallcaps}{font-family: "Baskervville", serif; font-variant: small-caps}
+\end{verbatim}
+
+\noindent Note that \hevea's default acts like an operator -- only
+setting \verb+font-variant: small-caps+ means: whatever font is
+current, use its downsized uppercase letters as small caps.  When the
+default of class~\verb+smallcaps+ is replaced with a definition that
+contains a \verb+font-family+ the operator character is lost and the
+original \LaTeX{} behavior is recovered.
+
+\paragraph{OpenType Feature: \verb+smcp+.}
+
+Some OpenType~fonts harbor their own small caps.  Not all browsers
+support the access of OpenType~features from CSS, but for those that
+do the following code activates the small caps in an sufficently
+``enriched'' OpenType~font.  See also the
+\footahref{https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Fonts/OpenType_fonts_guide}{OpenType~fonts
+  guide} and help on
+\footahref{https://helpx.adobe.com/fonts/using/use-open-type-features.html}{using
+  OpenType~features}.
+
+\begin{verbatim}
+\newstyle{.smallcaps}{%
+  font-variant-caps: small-caps;
+  font-feature-settings: "smcp";
+}
+\end{verbatim}
+
+\noindent Note: In the example right above any other
+font-feature-settings than \verb+smcp+ are cleared!
+
+If the browser supports the CSS at-rule \verb+@supports+ the recipe is
+improved by
+
+\begin{verbatim}
+\newstyle{.smallcaps}{font-feature-settings: "smcp"}
+\newstyle{@supports (font-variant-caps: small-caps)}{%
+  .smallcaps \{font-variant-caps: small-caps\}
+}
+\end{verbatim}
+
+\subsubsection{Oldstyle Numerals}
+
+\LaTeX{} \verb+\oldstylenums+ are not easily translated to the web
+because their glyphs cannot be synthesized.  The \hevea{} macro
+\verb+\oldstylenums+ accesses class~\verb+oldstyle+, which has no
+definition by default.  The most straightforward way to get oldstyle
+numerals is to rely on OpenType~font features with the following
+definitions:
+
+\begin{verbatim}
+\newstyle{.oldstyle}{font-feature-settings: "onum"}
+\newstyle{@supports (font-variant-numeric: oldstyle-nums)}{%
+  .oldstyle \{font-variant-numeric: oldstyle-nums\}
+}
+\end{verbatim}
+
+\noindent If a font has no oldstyle-nums the common numerals will be
+used.  In a pinch another font's numerals can be borrowed given the
+other font is highly similar.
+
+\subsubsection{Variable Typewriter Variant}
+
+\TeX{} offers a ``variable typewriter'' variant.  In fact this is a
+proportional font.  We can mimick this font with proportional
+typewriter fonts.
+
+\begin{verbatim}
+\ifhevea
+  \newstyle{.varispace}{font-family: Typewriter, monospace}
+  \newcommand{\textvtt}[1]{\mbox{\@span{class="varispace"}#1}}%
+\else
+  \newcommand{\variabletypewriter}{\fontfamily{cmvtt}\defaulthyphenchar=127\selectfont}%
+  \DeclareTextFontCommand{\textvtt}{\variabletypewriter}%
+\fi
+\end{verbatim}
+
+\noindent Now, macro~\verb+\textvtt+ could be used as a drop-in
+replacement for \verb+\texttt+.
+
+If no proportional typewriter font is readily available on the
+HTML-side, a similar effect is achieved with a slab-serif,
+proportional font, like for example ``Zilla Slab''.
+
+\subsubsection{Hints to Practitioners}
+
+Some hints to get legible and portable output.
+
+\begin{itemize}
+\item Restrict the selection to fonts that cover the the required set
+  of special characters (accented, mathematics, \dots).
+  H\aa{}mb\"urg\'ef\o{}\~ns!
+
+\item Choose families with at least four variations for
+  classes~\verb+serif+ and \verb+sansserif+:
+
+  \begin{enumerate}
+  \item regular,
+  \item italic/oblique,
+  \item bold, and
+  \item bold italic/bold oblique.
+  \end{enumerate}
+
+  If a variation is not available a browser may substitute a different
+  font or even try to synthesize the font, something typographers call
+  ``fake scaling, embolding and slanting''.  See also
+  CSS~\footahref{https://developer.mozilla.org/en-US/docs/Web/CSS/font-synthesis}{font-synthesis}.
+
+\item Class~\verb+monospace+ often is only needed in variants
+
+  \begin{enumerate}
+  \item regular and
+  \item oblique
+  \end{enumerate}
+
+  However, some authors like to typeset the reserved words of a
+  programming language in boldface.  They load package~``bold-extra''
+  for additional, bold typewriter fonts.  In this case it is also
+  advisable to use font families with four variations as described
+  above.
+
+\item Write down the full set of font-name aliases where applicable,
+  for example,
+
+  \begin{itemize}
+  \item \verb+"Courier New"+ and \verb+"Courier"+
+  \item \verb+"Trebuchet MS"+ and \verb+"Trebuchet"+
+  \item \verb+"Times New Roman"+ and \verb+"Times"+
+  \end{itemize}
+
+  Different operating systems may use different names for exactly the
+  same family.
+
+\item Pass attribute~\verb+font-style+ with classes~\verb+italic+ and
+  \verb+slanted+.  Override the default font~variant of
+  class~\verb+smallcaps+ with \verb+normal+ if the font~family
+  designates genuine small-caps fonts.
+
+\item Always put the default family in the last position of any
+  \verb+font-family+.
+
+\item Starting points for CSS~font selection.
+
+  \begin{itemize}
+    \newcommand{\tablenotesymbol}{\dagger}
+    \newcommand{\tablenotemark}{$^\tablenotesymbol$}
+    \newcommand{\tablenote}[1]{\tablenotemark:~{\footnotesize #1}}
+    \item Some ``workhorse'' font families that all have been designed
+      with online readability in mind.
+
+      \begin{tabular}{l@{\quad}l@{\quad}l@{\quad}l}
+        Family                    &  Serif             &  Sans Serif           &  Monospace  \\
+        \hline
+        %%  Prefer `DejaVu' to `Bitstream Vera'.
+        %Bitstream Vera            &  Bitstream Vera    &  Bitstream Vera Sans  &  Bitstream Vera Sans Mono  \\
+        DejaVu                    &  DejaVu Serif      &  DejaVu Sans          &  DejaVu Sans Mono  \\
+        Free                      &  FreeSerif         &  FreeSans             &  FreeMono  \\
+        IBM Plex                  &  IBM Plex Serif    &  IBM Plex Sans        &  IBM Plex Mono  \\
+        Lucida                    &  Lucida Bright     &  Lucida Sans          &  Lucida Sans Typewriter  \\
+        Noto\tablenotemark        &  Noto Serif        &  Noto Sans            &  Noto Mono  \\
+        Source Pro\tablenotemark  &  Source Serif Pro  &  Source Sans Pro      &  Source Code Pro  \\
+      \end{tabular}
+
+      \noindent\tablenote{OpenType-compliant font family, supporting for example oldstyle numerals.}
+
+    \item If the result looks too ``oldstyle'' try the sans serif font
+      also in the serif position or interchange sans serif and serif.
+
+    \item If the monospace font does not convey enough of an ``at the
+      terminal'' feeling give Anonymous Pro or Inconsolata a spin.
+      The latter font family also comes to the rescue when program
+      listings constantly are ``too wide'', this is, they overflow to
+      the right.  Inconsolata has variants ``Semi Condensed'',
+      ``Condensed'', ``Extra Condensed'', and ``Ultra Condensed''
+      among many others.
+  \end{itemize}
+
+\item Check the results with different browsers preferably on multiple
+  systems.
+\end{itemize}
 
 \section{Extra Features}\cutname{extras.html}
 This section describes \hevea{} functionalities that extends on plain \LaTeX{},

--- a/html/hevea.hva
+++ b/html/hevea.hva
@@ -309,7 +309,7 @@
 }\fi
 \@print{</head>
 }%
-\@print{<body }\@notags{\@bodyargs}\@print{>
+\@print{<body class="serif" }\@notags{\@bodyargs}\@print{>
 }%
 \@print{<!--HEVEA command line is: }\usebox{\@heveacomline}\@print{-->
 }%
@@ -378,11 +378,19 @@
 \newcommand{\@open@quote}[1]{\@open{blockquote}{#1}}
 \newcommand{\@close@quote}{\@close{blockquote}}
 %%%%%%%%%%%%%%%% LaTeX 2.09 style declarations
-\newenvironment{tt}{\@span{style="font-family:monospace"}}{}
+\newstyle{.serif}{font-family: serif}
+\newstyle{.sansserif}{font-family: sans-serif}
+\newstyle{.monospace}{font-family: monospace}
+\newstyle{.italic}{font-style: italic}
+\newstyle{.slanted}{font-style: oblique}
+\newstyle{.smallcaps}{font-variant: small-caps}
+%
+\newenvironment{tt}{\@span{class="monospace"}}{}
 \newenvironment{bf}{\@span{style="font-weight:bold"}}{}
 \newenvironment{em}{\@style{em}}{}
-\newenvironment{it}{\@span{style="font-style:italic"}}{}
-\newenvironment{rm}{\@anti{\it,\bf,\em,\sf,\tt}}{}
+\newenvironment{it}{\@span{class="italic"}}{}
+\newenvironment{rm}{\@anti{\it,\bf,\em,\sf,\tt}\@span{class="serif"}}{}
+\newenvironment{oldstyle}{\@span{class="oldstyle"}}{}
 \newenvironment{tiny}{\@fontsize{1}}{}
 \newenvironment{footnotesize}{\@fontsize{2}}{}
 \newenvironment{scriptsize}{\@fontsize{2}}{}
@@ -411,13 +419,13 @@
 \newenvironment{blue}{\@fontcolor{blue}}{}
 \newenvironment{teal}{\@fontcolor{teal}}{}
 \newenvironment{aqua}{\@fontcolor{aqua}}{}
-\def\cal{\ifmath\ifmathml\@style{font-family: cursive }%
+\def\cal{\ifmath\ifmathml\@style{font-family: cursive}%
 \else\red\fi\else\red\fi}
-\def\sf{\ifmath\ifmathml\@style{font-family: sans-serif }%
-\else\@span{style="font-family:sans-serif"}\fi\else\@span{style="font-family:sans-serif"}\fi}
-\def\sl{\ifmath\ifmathml\@style{font-family: fantasy; font-style: italic }%
-\else\@span{style="font-style:oblique"}\fi\else\@span{style="font-style:oblique"}\fi}
-\def\sc{\@span{style="font-variant:small-caps"}}%
+\def\sf{\ifmath\ifmathml\@style{font-family: sans-serif}%
+\else\@span{class="sansserif"}\fi\else\@span{class="sansserif"}\fi}
+\def\sl{\ifmath\ifmathml\@style{font-family: fantasy; font-style: italic}%
+\else\@span{class="slanted"}\fi\else\@span{class="slanted"}\fi}
+\def\sc{\@span{class="smallcaps"}}%
 %%%% LaTeX2e verbose declarations
 \newenvironment{mdseries}{\@anti{\bf}}{}
 \newenvironment{bfseries}{\bf}{}
@@ -441,6 +449,7 @@
 \def\textsl#1{\mbox{\slshape#1}}
 \def\textsc#1{\mbox{\scshape#1}}
 \newcommand{\emph}[1]{\mbox{\em#1}}
+\newcommand{\oldstylenums}[1]{\mbox{\oldstyle#1}}%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %  New implementation of \sc & \textsc using "small-caps" style. %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Hevea "hard-codes" `font-family: monospace` for typewriter text.
Obviously, this has not riled anybody until now.  If you are chasing a
consistent appearance of the Hevea-translated document or simply
want to swap out this bland default monospace font, things change.

This P/R introduces CSS-classes for six font families or font
variants:

  * serif
  * sansserif
  * monospace
  * italic
  * slanted
  * smallcaps

The existing `\@span` calls are adjusted accordingly and new `\@span`s
are introduced where necessary.  The defaults leave unaffected the
appearance of all translated documents.  So this is a visually neutral
change, which actually is quite small.  The much larger change is a
rewrite of chapter B.15 "Font Selection" of the reference manual along
with an additional subsection on "Controlling Font Selection with
CSS".


Here is a little demo document to play around with.

```latex
%%%  font-selection.tex
\documentclass{article}

\usepackage{bold-extra}         % bold typewriter
\usepackage{hevea}

%%  Also try (super-) families...
%%      "Go" / "Go" / "Go Mono"
%%      "DejaVu Serif" / "DejaVu Sans" / "DejaVu Sans Mono"
%%      "Noto Serif" / "Noto Sans" / "Noto Mono"
%%      "Georgia" / "Trebuchet MS" / "Courier New" and rescale monospace with `font-size: 120\%'
\newcommand*{\seriffontfamily}{"FreeSerif", serif}
\newcommand*{\sansfontfamily}{"FreeSans", sans-serif}
\newcommand*{\fixedfontfamily}{"FreeMono", monospace}

%%  Uncomment to activate...
%%  \newstyle{.serif}{font-family: \seriffontfamily}
%%  \newstyle{.sansserif}{font-family: \sansfontfamily}
%%  \newstyle{.monospace}{font-family: \fixedfontfamily}

%%  Fill in your fonts of choice and compare.
%%  \newstyle{.italic}{font-family: ...;
%%                     font-style: italic}
%%  \newstyle{.slanted}{font-family: ...;
%%                      font-style: oblique}

%%  \newstyle{.smallcaps}{font-family: ...;
%%                        font-variant: small-caps}% or: `font-variant: normal' for SC-fonts

\newstyle{.oldstyle}{font-feature-settings: "onum"}
\newstyle{@supports (font-variant-numeric: oldstyle-nums)}{%
  .oldstyle \{font-variant-numeric: oldstyle-nums\}
}

\newstyle{.chapter, .section, .subsection, .subsubsection}{font-family: \sansfontfamily}

\newcommand*{\shortphrase}{White Handgloves}
\newcommand*{\longphrase}{The quick brown fox jumps over the lazy dog.}

\begin{document}
\section{Font Samples}
\begin{description}
\item[Roman:] \textrm{\longphrase}
\item[Italic:] \textit{\longphrase}  And emphasized: \emph{\shortphrase.}
\item[Bold:] \textbf{\longphrase}
\item[Bold Italic:] \textit{\textbf{\longphrase}}
\item[Sans Serif:] \textsf{\longphrase}
\item[Oblique Sans Serif:] \textsl{\textsf{\longphrase}}
\item[Bold Sans Serif:] \textsf{\textbf{\longphrase}}
\item[Bold Oblique Sans Serif:] \textbf{\textsl{\textsf{\longphrase}}}
\item[Typewriter:] \texttt{\longphrase}
\item[Bold Typewriter:] \textbf{\texttt{\longphrase}}
\item[Oblique Typewriter:] \textsl{\texttt{\longphrase}}
\item[Bold Oblique Typewriter:] \textbf{\textsl{\texttt{\longphrase}}}
\item[Slanted:] \textsl{\longphrase}
\item[Small Caps:] \textsc{\longphrase}
\item[Oldstyle Numerals:] \oldstylenums{0123456789} vs.~0123456789.
\end{description}

\section{Paragraph Text}
In This Paragraph We Intentionally Start Every Word With A Capital
Letter!  The \textrm{Roman Typeface} And The \texttt{Typewriter Face}
Must Match In \textrm{Visual Size} For A \texttt{Uniform Appearance}.
Well, At Least \textit{As Much As\/} This Is
\textit{\texttt{Possible\/}} On A \texttt{Web Page}.

\section{Roman/Italics/Slanted}
\begin{itemize}
\item \textrm{\longphrase} (roman)
\item \textit{\longphrase} (italics)
\item \textsl{\longphrase} (slanted)
\end{itemize}
\end{document}
```

What this P/R fixes:
  * Overriding class `monospace` allows the user to select and scale a
    font family for `\texttt`.
  * Overriding classes `serif`, `sansserif`, and `monospace` together
    lets the user determine a font super family.
  * Defining class `slanted` or `italic` can be used to remedy
    mapping of `\textsl` and `\textit` to the same font.
  * Implementing a `smallcaps` class can be used to pair a dedicated
    small-caps font for an existing regular one or to access built-in
    small-caps in certain OpenType fonts.
  * Introduce macro `\oldstylenums` and make it refer to class
    `oldstyle`, which is undefined by default.

Open questions:
  * Would we benefit from a separate command for CSS at rules?
    Currently:

```latex
\newstyle{@supports (font-variant-caps: small-caps)}{%
    .smcp \{font-variant-caps: small-caps\}
}
```

With `\newatrule{name}[arg, ...]{body}`:

```latex
\newatrule{.smcp}[font-variant-caps: small-caps]{%
    .smcp \{font-variant-caps: small-caps\}
}
```

What doesn't work yet:
  * Consistent scaling of all class application points, i.e. implementing
    LaTeX document class options `11pt` and `12pt`.
  * Math-mode display (outside of the scope of this P/R).
