### PR TITLE
Emulate "\discretionary" and implement "\-".

### DIFF
--- a/latexcommon.hva
+++ b/latexcommon.hva
@@ -251,27 +251,16 @@
 %%%%%%%%%%%% Emulate hyphenation
 \newcommand{\soft@hyphen}{\@print{&#173;}}
 \newcommand{\zero@width@space}{\@print{&#8203;}}
+\newcommand{\breakable@hyphen}{\@print{&#8208;}}
 \newcommand{\tag@wordbreak}{\@print{<wbr>}}
 \newcommand{\word@break@opportunity}{\tag@wordbreak}% use e.g. `\zero@width@space' or `\tag@wordbreak'
 \newcommand{\-}{\soft@hyphen}
 \newcommand{\hyphenation}[1]{}
 \newcommand{\discretionary}[3]{%
-  \def\twoargs{#2#3}%
-  \def\threeargs{#1#2#3}%
-  \ifx\threeargs\@empty
-    \word@break@opportunity
-  \else
-    \ifx\twoargs\@empty
-      \ifx#1-%
-        \soft@hyphen
-      \else
-        #3%
-      \fi
-    \else
-      #3%
-    \fi
-  \fi
-}
+  \ifthenelse{\equal{#1#2#3}{}}{\word@break@opportunity}{%
+    \ifthenelse{\equal{#1}{-}\and\equal{#2#3}{}}{\soft@hyphen}{%
+      \ifthenelse{\equal{#1}{-}\and\equal{#2}{}\and\equal{#3}{-}}{\breakable@hyphen}{%
+        #3}}}}
 %% Page Breaking
 \newcommand{\pagebreak}[1][]{}
 \newcommand{\nopagebreak}[1][]{}

--- a/latexcommon.hva
+++ b/latexcommon.hva
@@ -251,6 +251,7 @@
 %%%%%%%%%%%% Emulate hyphenation
 \newcommand{\soft@hyphen}{\@print{&#173;}}
 \newcommand{\zero@width@space}{\@print{&#8203;}}
+\newcommand{\zero@width@non@joiner}{\@print{&#8204;}}
 \newcommand{\breakable@hyphen}{\@print{&#8208;}}
 \newcommand{\tag@wordbreak}{\@print{<wbr>}}
 \newcommand{\word@break@opportunity}{\tag@wordbreak}% use e.g. `\zero@width@space' or `\tag@wordbreak'

--- a/latexcommon.hva
+++ b/latexcommon.hva
@@ -248,9 +248,30 @@
 \newcommand{\fussy}{}
 \newenvironment{sloppypar}{}{}
 \newcommand{\goodbreak}{}
-%%%%%%%%%%%% Ignore hyphenation
-\newcommand{\-}{}
+%%%%%%%%%%%% Emulate hyphenation
+\newcommand{\soft@hyphen}{\@print{&#173;}}
+\newcommand{\zero@width@space}{\@print{&#8203;}}
+\newcommand{\tag@wordbreak}{\@print{<wbr>}}
+\newcommand{\word@break@opportunity}{\tag@wordbreak}% use e.g. `\zero@width@space' or `\tag@wordbreak'
+\newcommand{\-}{\soft@hyphen}
 \newcommand{\hyphenation}[1]{}
+\newcommand{\discretionary}[3]{%
+  \def\twoargs{#2#3}%
+  \def\threeargs{#1#2#3}%
+  \ifx\threeargs\@empty
+    \word@break@opportunity
+  \else
+    \ifx\twoargs\@empty
+      \ifx#1-%
+        \soft@hyphen
+      \else
+        #3%
+      \fi
+    \else
+      #3%
+    \fi
+  \fi
+}
 %% Page Breaking
 \newcommand{\pagebreak}[1][]{}
 \newcommand{\nopagebreak}[1][]{}

--- a/latexcommon.hva
+++ b/latexcommon.hva
@@ -252,7 +252,6 @@
 \newcommand{\soft@hyphen}{\@print{&#173;}}
 \newcommand{\zero@width@space}{\@print{&#8203;}}
 \newcommand{\breakable@hyphen}{\@print{&#8208;}}
-\newcommand{\word@joiner}{\@print{&#8288;}}
 \newcommand{\tag@wordbreak}{\@print{<wbr>}}
 \newcommand{\word@break@opportunity}{\tag@wordbreak}% use e.g. `\zero@width@space' or `\tag@wordbreak'
 \newcommand{\-}{\soft@hyphen}

--- a/latexcommon.hva
+++ b/latexcommon.hva
@@ -252,6 +252,7 @@
 \newcommand{\soft@hyphen}{\@print{&#173;}}
 \newcommand{\zero@width@space}{\@print{&#8203;}}
 \newcommand{\breakable@hyphen}{\@print{&#8208;}}
+\newcommand{\word@joiner}{\@print{&#8288;}}
 \newcommand{\tag@wordbreak}{\@print{<wbr>}}
 \newcommand{\word@break@opportunity}{\tag@wordbreak}% use e.g. `\zero@width@space' or `\tag@wordbreak'
 \newcommand{\-}{\soft@hyphen}


### PR DESCRIPTION
Hevea lacks the `\discretionary` macro which means words that need
it (on the LaTeX side) get butchered in the HTML output.  This P/R
implements just as much of
```tex
\discretionary{pre-break}{post-break}{no-break}
```
that the special cases `\discretionary{}{}{}` (empty discretionary) and
`\discretionary{-}{}{}` (simple hyphenation point) are covered and all
others simply expand to `no-break`.

Mapping of the empty discretionary to "word-break opportunity":
Some browser interpret the zero-width space character, some the HTML5
tag `wbr`, and presumable others do not understand either.  So, we have
introduced an extra level of indirection called `\word@break@opportunity`,
which can be redefined by the user to get the desired translation of
`\discretionary{}{}{}`.  The default is `wbr`.

TeX macro `\-` directly maps to the soft hyphen.
