### PR TITLE
Aligned equation numbers

### DIFF
--- a/latexcommon.hva
+++ b/latexcommon.hva
@@ -50,8 +50,17 @@
 \def\@changelabel
   {\let\@oldlabel\label%
   \renewcommand{\label}[1]{\@oldlabel[~]{##1}}}
-\newcommand{\eqno}[1]{\qquad#1}
-\newenvironment{equation}{\[\@changelabel\refstepcounter{equation}}{\eqno{(\theequation)}\]}
+\newstyle{.equationcontainer}{position:relative;}
+\def\@eqnnumstyle{float:right;left:auto;position:absolute;right:0}
+\newstyle{.equationnumber}{\@eqnnumstyle}
+\newcommand{\set@equ@num@align}[1]{%
+  \ifthenelse{\equal{#1}{leqno}}{\def\@eqnnumstyle{float:left;left:0;position:absolute;right:auto}}{}%
+}
+\newcommand{\honor@leqno@option}{%
+  \@callprim{\@iter}{\string\set@equ@num@align,{\char123\usebox{\@document@opts}\char125}}
+}
+\newcommand{\eqno}[1]{\@open{span@inline@block}{class="equationnumber"}#1\@close{span@inline@block}}
+\newenvironment{equation}{\@open{div}{class="equationcontainer"}\[\@changelabel\refstepcounter{equation}}{\eqno{(\theequation)}\]\@close{div}}
 \newenvironment{eqnarray*}{$$\begin{array}{rcl}}{\end{array}$$}
 \gdef\@yes@number{\eqno{(\theequation)}}
 \gdef\@no@number{\addtocounter{equation}{-1}}
@@ -63,7 +72,7 @@
 \let\@HEVEA@lefteqn\lefteqn
 \newenvironment{eqnarray}
 {\@ifundefined{@eqna@inside}{\def\@eqna@inside{}}{\hva@warn{Nested eqnarray}}%
-\[\@changelabel\def\@currentlabel{\theequation}%
+\@open{div}{class="equationcontainer"}\[\@changelabel\def\@currentlabel{\theequation}%
 \setcounter{@eqna@col}{0}\@yesnumber\stepcounter{equation}
 \let\@PBS=\@HEVEA@bsbs
 \let\@PAM=\@HEVEA@amper
@@ -76,7 +85,7 @@
     {\hva@warn{Extra column in eqnarray}}}     
 \renewcommand{\\}[1][]{\@eqna@complete\@PAM\@number\setcounter{@eqna@col}{0}\@yesnumber\stepcounter{equation}\@PBS}
 \@array{rclr}}
-{\\{}\addtocounter{equation}{-1}\end@array\]}
+{\\{}\addtocounter{equation}{-1}\end@array\]\@close{div}}
 \def\mathrm#1{{\rm#1}}
 \def\mathtt#1{{\tt#1}}
 \def\mathit#1{{\it#1}}
@@ -344,6 +353,8 @@
 %%% Paragraphs
 \let\par\@empty
 \AtBeginDocument{\let\par\hva@par}
+%%% Equations
+\AtBeginDocument{\honor@leqno@option}
 %%% References
 \newcommand{\@currentlabel}{}
 %%% Index references

--- a/latexcommon.hva
+++ b/latexcommon.hva
@@ -53,13 +53,15 @@
 \newstyle{.equationcontainer}{position:relative;}
 \def\@eqnnumstyle{float:right;left:auto;position:absolute;right:0}
 \newstyle{.equationnumber}{\@eqnnumstyle}
+\newstyle{.equationnumber-valign}{\@eqnnumstyle;margin-top:-0.5em;}
+\def\@equationnumber@class{equationnumber}
 \newcommand{\set@equ@num@align}[1]{%
   \ifthenelse{\equal{#1}{leqno}}{\def\@eqnnumstyle{float:left;left:0;position:absolute;right:auto}}{}%
 }
 \newcommand{\honor@leqno@option}{%
   \@callprim{\@iter}{\string\set@equ@num@align,{\char123\usebox{\@document@opts}\char125}}
 }
-\newcommand{\eqno}[1]{\@open{span@inline@block}{class="equationnumber"}#1\@close{span@inline@block}}
+\newcommand{\eqno}[1]{\@open{span@inline@block}{class="\@equationnumber@class"}#1\@close{span@inline@block}}
 \newenvironment{equation}{\@open{div}{class="equationcontainer"}\[\@changelabel\refstepcounter{equation}}{\eqno{(\theequation)}\]\@close{div}}
 \newenvironment{eqnarray*}{$$\begin{array}{rcl}}{\end{array}$$}
 \gdef\@yes@number{\eqno{(\theequation)}}
@@ -72,6 +74,7 @@
 \let\@HEVEA@lefteqn\lefteqn
 \newenvironment{eqnarray}
 {\@ifundefined{@eqna@inside}{\def\@eqna@inside{}}{\hva@warn{Nested eqnarray}}%
+\def\@equationnumber@class{equationnumber-valign}%
 \@open{div}{class="equationcontainer"}\[\@changelabel\def\@currentlabel{\theequation}%
 \setcounter{@eqna@col}{0}\@yesnumber\stepcounter{equation}
 \let\@PBS=\@HEVEA@bsbs


### PR DESCRIPTION
This PR aligns equation numbers flush to the right (default) or the
left (document option "leqno") margin similar to LaTeX.

Here is an example source file to try the change:

```latex
\documentclass[]{article}% try option: `leqno'

\usepackage{hevea}

\ifhevea
  \renewcommand{\vec}[1]{\mathbf{#1}}
\fi

\newif\ifnabla\nablafalse
\newcommand*{\grad}{\ifnabla\ensuremath{\nabla}\else\mbox{grad}\fi}
\renewcommand*{\div}{\ifnabla\ensuremath{\nabla \cdot}\else\mbox{div}\fi}
\newcommand*{\curl}{\ifnabla\ensuremath{\nabla \times}\else\mbox{curl}\fi}

%%  Comment-out to get default layout.
\newstyle{body}{margin: auto; max-width: 36em; width: 60\%}

%%  Uncomment to revert to old behavior.
%\newstyle{.equationnumber}{float: none; left: 2em; position: relative; right: auto}
%\newstyle{.equationnumber-valign}{float: none; left: auto; margin-top: auto; position: relative; right: auto}

\begin{document}
\begin{equation}
  \frac{\partial \rho}{\partial t} + \div \vec{\jmath} = 0
\end{equation}

\begin{eqnarray}
  \int_S \vec{E} \cdot d\vec{S}  &  =  &  \int_V \rho\,d\/{}^{3}\!x  \\
  \oint_C \vec{B} \cdot d\vec{x}  &  =  &  \int_S \left(\vec{\jmath} + \frac{\partial \vec{E}}{\partial t}\right) d\vec{S}  \\
  \int_S \vec{B} \cdot d\vec{S}  &  =  &  0  \\
  -\oint_C \vec{E} \cdot d\vec{x}  &  =  &  \int_S d\vec{S} \cdot \frac{\partial \vec{B}}{\partial t}
\end{eqnarray}
\end{document}
```

I have split the change in two patches: The first is the one I wanted to write,
but it interferes with vertical alignment in a mysterious way.  Therefore I "fixed"
the vertically misaligned numbers in `eqnarray` with the second patch.
@maranget, if you know of a better way please revert the last patch and
substitute a cleaner solution.
