### PR TITLE
Improve "quote" and "quotation".  Implement "verse".

### DIFF
--- a/doc/text.tex
+++ b/doc/text.tex
@@ -4583,13 +4583,18 @@ appear directly inside a displayed-paragraph environment or inside an array
 element.
 
 
-
 \subsection{Quotation and Verse}
-The \verb+quote+ and \verb+quotation+ environments are the same thing: they
-translate to \verb+BLOCKQUOTE+ elements.
-The \verb+verse+ environment is not supported.
+
+The \verb+quote+ and \verb+quotation+~environments are similar; they
+translate to \verb+BLOCKQUOTE+~elements with associated
+classes~\verb+quote+ and \verb+quotation+, respectively.
+
+The \verb+verse+~environment is supported as \verb+BLOCKQUOTE+~element
+with class~\verb+verse+.
+
 
 \subsection{List-Making environments}
+
 The \verb+itemize+, \verb+enumerate+ and \verb+description+
 environments translate to the \verb+ul+, \verb+ol+, and
 \verb+DL+ elements and this is the whole story.

--- a/html/hevea.hva
+++ b/html/hevea.hva
@@ -365,13 +365,20 @@
   {\@close{div}}%
 \newcommand{\centerline}[1]{\begin{center}#1\end{center}}
 %%quotations env.
+\newstyle{.quote}{margin-left:3em;margin-right:3em;text-align:inherit;text-indent:0pt}
 \setenvclass{quote}{quote}%
 \newenvironment{quote}
 {\@close{}\@open{blockquote}{\envclass@attr{quote}}}
 {\@close{blockquote}\@open{}{}}%
+\newstyle{.quotation}{margin-left:3em;margin-right:3em;text-align:inherit;text-indent:1.5em}
 \setenvclass{quotation}{quotation}%
 \newenvironment{quotation}
 {\@open{blockquote}{\envclass@attr{quotation}}}{\@close{blockquote}}
+\newstyle{.verse}{margin-left:3em;margin-right:3em;text-indent:1.5em hanging each-line}
+\setenvclass{verse}{verse}%
+\newenvironment{verse}
+{\@close{}\@open{blockquote}{\envclass@attr{verse}}}
+{\@close{blockquote}\@open{}{}}%
 \newcommand{\centering}{\@insert{div}{\envclass@attr{center}}}
 \newcommand{\raggedleft}{\@insert{div}{\envclass@attr{flushright}}}
 \newcommand{\raggedright}{\@insert{div}{\envclass@attr{flushleft}}}


### PR DESCRIPTION
Make the translations of `quote` and `quotation` faithfully follow LaTeX
and implement the `verse`-environment.

The CSS-code for `verse` already uses the upcoming extension of the
`text-indent` property

```
        hanging each-line
```

which duplicates the LaTeX behavior of indenting wrapped lines,
i.e., should be exactly what we need.  See
    https://www.w3.org/TR/css-text-3/#text-indent-property
and also
    https://developer.mozilla.org/en-US/docs/Web/CSS/text-indent

In all three cases the documentation has been updated or extended
according to the changes.