### PR TITLE
CSS class for \verb and visual spaces for starred versions

### DIFF
--- a/doc/text.tex
+++ b/doc/text.tex
@@ -4657,21 +4657,21 @@ This yields:
 \item Second item.
 \end{list}
 
-
 The \verb+trivlist+ environment is also supported. It is equivalent to
 the \verb+description+ environment.
+
 
 \subsection{Verbatim}
 
 The \verb+verbatim+ and \verb+verbatim*+ environments translate to
-the \verb+PRE+ element.
-Inside \verb+verbatim*+, spaces are replaced by underscores (``\verb*+ +'').
-
-
-Similarly, \verb+\verb+ and \verb+\verb*+
-translate to the \verb+CODE+ text element.
+the \verb+PRE+~elements.  Inside \verb+verbatim*+, spaces are replaced
+by visual spaces (``\verb*+ +'').  Similarly, \verb+\verb+
+and \verb+\verb*+ translate to \verb+CODE+ text elements.  The
+environments are associated with CSS~classes of the same names, this
+is, \verb+verbatim+ and \verb+\verb+, respectively.
 
 The \verb+alltt+ environment is supported.
+
 
 \section{Mathematical Formulae}
 

--- a/outUnicode.ml
+++ b/outUnicode.ml
@@ -834,11 +834,12 @@ let html_put put put_char i = match i with
 
 (* Constants *)
 
-let space = 0X20
-and nbsp = 0XA0
+let space = 0x20
+and nbsp = 0xA0
+and visible_space = 0x2423
 and acute_alone = 0xB4
-and grave_alone = 0X60
-and circum_alone = 0X5E
+and grave_alone = 0x60
+and circum_alone = 0x5E
 and diaeresis_alone = 0xA8
 and cedilla_alone = 0xB8
 and tilde_alone = 0x7E

--- a/outUnicode.mli
+++ b/outUnicode.mli
@@ -67,6 +67,7 @@ val html_put : (string -> unit) -> (char -> unit) -> unichar -> unit
 val null : unichar
 val space : unichar
 val nbsp : unichar
+val visible_space : unichar
 val acute_alone : unichar
 val grave_alone : unichar
 val circum_alone : unichar

--- a/verb.mll
+++ b/verb.mll
@@ -995,20 +995,20 @@ let _ = ()
 ;;
 
 let put_char_star c next = match c with
-  | ' '|'\t' -> Dest.put_char '_' ;
+  | ' ' | '\t' -> Dest.put_unicode OutUnicode.visible_space;
   | c -> Scan.translate_put_unicode c next
 
 and put_char c next = match c with
-  |  '\t' -> Dest.put_char ' '
-  | c ->  Scan.translate_put_unicode c next
+  | '\t' -> Dest.put_char ' '
+  | c -> Scan.translate_put_unicode c next
 ;;
 
 
 let open_verb put lexbuf =
-  Dest.open_group "code" ;
+  Dest.open_group "code class=\"verb\"";
   start_inverb put lexbuf
 ;;
-  
+
 def_code "\\verb" (open_verb put_char) ;
 def_code "\\verb*" (open_verb put_char_star);
 ();;


### PR DESCRIPTION
Associate `\verb` and `\verb*` (which translate into `code` elements)
with CSS class `verb`.

In `\verb*` and in `verbatim*` environments use the Unicode
"visible space" character to indicate spaces or tabs instead of
an ASCII underscore.
