### PR TITLE
Fix HTML-generation bug introduced in P/R #34

### DIFF
--- a/html/hevea.hva
+++ b/html/hevea.hva
@@ -704,8 +704,9 @@
 #1%
 \fi\fi
 \@close{span@inline@block}}
-%%%%%%%%Default env class for verbatim
+%%%%%%%%Default env classes for verbatim and verb
 \setenvclass{verbatim}{verbatim}
+\setenvclass{verb}{verb}
 %%%%%% format theorems
 \newcommand{\set@th@font}[1]{\def\th@font{#1}}
 \let\th@font\em

--- a/verb.mll
+++ b/verb.mll
@@ -834,7 +834,7 @@ let command_name =
 rule inverb verb_delim put = parse
 |  (_ as c)
     {if c = verb_delim then begin
-      Dest.close_group () ;
+      Dest.close_block "code";
     end else begin
       put c (fun () -> read_lexbuf lexbuf) ;
       inverb verb_delim put lexbuf
@@ -1004,8 +1004,10 @@ and put_char c next = match c with
 ;;
 
 
+let getclass env = Scan.get_prim (Printf.sprintf "\\envclass@attr{%s}" env)
+
 let open_verb put lexbuf =
-  Dest.open_group "code class=\"verb\"";
+  Dest.open_block ~force_inline:true "code" (getclass "verb");
   start_inverb put lexbuf
 ;;
 
@@ -1030,8 +1032,6 @@ let noeof lexer lexbuf =
         (Misc.Close
            ("End of file in environment: ``"^ !Scan.cur_env^"'' ("^s^")"))
   | EndVerb -> ()
-
-let getclass env = Scan.get_prim (Printf.sprintf "\\envclass@attr{%s}" env)
 
 let open_verbenv star =
   Scan.top_open_block "pre" (getclass "verbatim") ;


### PR DESCRIPTION
A HTML-generation bug has been introduced with #34 

Problem: 
```ocaml
    Dest.open_group "code class=\"verb\""
```

constructs the HTML group

```html
    <code class="verb">
    ...
    </code class="verb">
```

which is invalid HTML as closing elements never have attributes.

Solution: Use `Dest.open_block` which allows to pass an attribute.

En passant: Associate `\verb` with CSS-class `verb` via `\setenvclass`.
