### PR TITLE
Drop non-breaking space (TeX: `~') if chaptername is empty.

### DIFF
--- a/html/book.hva
+++ b/html/book.hva
@@ -1,6 +1,5 @@
 \ifstyleloaded\relax
 \else
-\input{ifthen.hva}
 \input{bookcommon.hva}
 \newcommand{\@book@attr}[1]{\@secid\envclass@attr{#1}}
 \@makesection

--- a/html/book.hva
+++ b/html/book.hva
@@ -1,5 +1,6 @@
 \ifstyleloaded\relax
 \else
+\input{ifthen.hva}
 \input{bookcommon.hva}
 \newcommand{\@book@attr}[1]{\@secid\envclass@attr{#1}}
 \@makesection
@@ -10,7 +11,8 @@
 \newstyle{.part}{margin:2ex auto;text-align:center}
 \@makesection
   {\chapter}{-1}{chapter}
-   {\@open{h1}{\@book@attr{chapter}}}{\chaptername~\thechapter}{\quad}{\@close{h1}}
+   {\@open{h1}{\@book@attr{chapter}}}%
+   {\ifthenelse{\equal{\chaptername}{}}{}{\chaptername~}\thechapter}{\quad}{\@close{h1}}
 \@makesection
   {\section}{0}{section}
   {\@open{h2}{\@book@attr{section}}}{\thesection}{\quad}{\@close{h2}}%

--- a/html/book.hva
+++ b/html/book.hva
@@ -12,7 +12,7 @@
 \@makesection
   {\chapter}{-1}{chapter}
    {\@open{h1}{\@book@attr{chapter}}}%
-   {\ifthenelse{\equal{\chaptername}{}}{}{\chaptername~}\thechapter}{\quad}{\@close{h1}}
+   {\ife\chaptername{}\else\chaptername~\fi\thechapter}{\quad}{\@close{h1}}
 \@makesection
   {\section}{0}{section}
   {\@open{h2}{\@book@attr{section}}}{\thesection}{\quad}{\@close{h2}}%


### PR DESCRIPTION
This patch fixes #30 