### PR TITLE
Introduce the macros `\phantom', `\hphantom', `\vphantom', and `\smash'.

### DIFF
--- a/latexcommon.hva
+++ b/latexcommon.hva
@@ -143,6 +143,19 @@
   {\prim@def{\@table@attributes}{style="border:0;border-spacing:\space@varray{};border-collapse:separate" class="cellpadding0"}\def\space@varray{0}%
   \begin{array}{c}}
   {\end{array}}
+%% Phantom
+\newstyle{.phantom}{display: inline-block; visibility: hidden}
+\newstyle{.hphantom}{display: inline-block; height: 0; visibility: hidden}
+\newstyle{.vphantom}{display: inline-block; visibility: hidden; width: 0}
+\newstyle{.smash}{display: inline-block; height: 0; line-height: 0}
+\setenvclass{phantom}{phantom}
+\setenvclass{hphantom}{hphantom}
+\setenvclass{vphantom}{vphantom}
+\setenvclass{smash}{smash}
+\newcommand{\phantom}[1]{\@open{span@inline@block}{\envclass@attr{phantom}}#1\@close{span@inline@block}}
+\newcommand{\hphantom}[1]{\@open{span@inline@block}{\envclass@attr{hphantom}}#1\@close{span@inline@block}}
+\newcommand{\vphantom}[1]{\@open{span@inline@block}{\envclass@attr{vphantom}}#1\@close{span@inline@block}}
+\newcommand{\smash}[1]{\@open{span@inline@block}{\envclass@attr{smash}}#1\@close{span@inline@block}}
 %%% OLD DEFINITIONS : rediscovered, only \textoverline redefined in hevea.hva
 %%%
 \newcommand{\textoverline}[1]{\hva@warn{overline ignored in text mode}#1}


### PR DESCRIPTION
These definitions arose serendepitously from looking at CSS property ```visibility```
recalling the superficial similarity of ```\makebox``` with CSS ```inline-block```.

Working example:

```latex
\documentclass{article}

\usepackage{hevea}
\usepackage{parskip}

\newstyle{body}{%
  margin: auto;
  max-width: 32em;
  line-height: 100\%;
  text-align: justify;
  width: 55\%;
}

\begin{document}
\section{\textbackslash phantom}
ABC.

A\phantom{B}C.

\section{\textbackslash hphantom}
$$
    \begin{array}{l}
      Side Middle Side  \\
      S\hphantom{ide\ }M\hphantom{iddle\ }Side  \\
    \end{array}
$$

\section{\textbackslash vphantom}
Without \verb+\vphantom+:

$$
    \sqrt{a}\cdot\sqrt{a^3}
$$

With \verb+\vphantom+:

$$
    \sqrt{\vphantom{a^3}a}\cdot\sqrt{a^3}
$$

\section{\textbackslash smash}
To demonstrate the effect of smash we need at least one line of
running text before it.  To compute the tetration
$\smash{2^{2^{2^2}}}$, evaluate from the top down, as $2^{2^{2^2}} =
2^{2^4} = 2^{16} = 65536$.
\end{document}
```
