### PR TITLE
Fix HTML-generation bug introduced in P/R #18

### DIFF
--- a/imakeidx.hva
+++ b/imakeidx.hva
@@ -40,7 +40,7 @@
   \ifthenelse{\boolean{imakeidx@makeindex@intoc}}%
              {\addcontentsline{toc}%
                {\imakeidx@indexsetup@toclevel}%
-               {\ahrefloc{section@the@hevea@index}{\indexname}}}%
+               {\ahrefloc{section@the@hevea@index@\imakeidx@makeindex@name}{\indexname}}}%
              {}%
   \@printindex[\imakeidx@makeindex@name]%
 }

--- a/index.ml
+++ b/index.ml
@@ -334,8 +334,8 @@ let newindex tag sufin sufout name =
 let print main tag =
   try
     let idx = find_index tag in
-    main "\\label{section@the@hevea@index}";
-    main ("\\@indexsection{"^idx.name^"}") ;
+    main ("\\label{section@the@hevea@index@" ^ tag ^ "}");
+    main ("\\@indexsection{" ^ idx.name ^ "}") ;
     main "\\begin{the@hevea@index}";
     let indname = index_filename idx.sufout in
     begin match idx.from_file with


### PR DESCRIPTION
Fix "multiple label definition" bug in \@printindex and \printindex
that was introduced in P/R #18

Macros `\@printindex` and `\printindex` of package _imakeidx.hva_ define the
label `section@the@hevea@index`.  Multiple indices generate multiple
definitions for this label.  The result is an invalid HTML file.

This patch fixes the problem by appending the index name to the label,
which results in `section@the@hevea@index@default` for the default
case.

Found by **xmllint**.
