### PR TITLE
Implement \makebox and \framebox; re-implement \fbox.

### DIFF
--- a/amsmath.hva
+++ b/amsmath.hva
@@ -179,7 +179,7 @@
 %%%%%%%%%%%%%%%%%
 % \boxed command%
 %%%%%%%%%%%%%%%%%
-\NewcommandHtml{\boxed}{\DisplayChoose\@@boxed\@boxed}
+\NewcommandHtml{\boxed}[1]{\fbox{#1}}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Table 48: AMS Variable-sized Math Operators %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/doc/text.tex
+++ b/doc/text.tex
@@ -5473,7 +5473,7 @@ arguments.  Such arguments get converted to a number of non-breaking
 spaces or line breaks.
 Basically, the value of \verb+1em+ or \verb+1ex+ is one space or one
 line-break. For other length units, a simple conversion based upon a
-10pt font is used.
+12pt font is used.
 
 
 \hevea{} cannot interpret more complicated length arguments
@@ -5489,28 +5489,21 @@ breaks.
 Stretchable lengths do not exist, thus the \verb+\hfill+ and
 \verb+\vfill+ macros are undefined.
 
+
 \subsection{Boxes}
 
-Box contents is typeset in text mode (\emph{i.e.}\ non-math and non-display
-mode).
-Both \LaTeX{} boxing commands \verb+\mbox+ and \verb+\makebox+
-commands exist.
-However  \verb+\makebox+ generates a specific warning, since \hevea{}
-ignore the length and positioning instructions given as optional
-argument.
+Box contents is typeset in text mode (\emph{i.e.} non-math,
+non-display mode).  Both \LaTeX{} boxing commands \verb+\mbox+ and
+\verb+\makebox+ exist.  The latter is associated with
+class~\verb+makebox+, which is empty by default and can be redefined
+by the user.
 
-Similarly, the boxing with frame \verb+\fbox+ and \verb+\framebox+
-commands are recognised and
-\verb+\framebox+ issues a warning.
-When in display mode, \verb+\fbox+ frames its argument by
-enclosing it in a
-table with borders. Otherwise, \verb+\fbox+ calls the \verb+\textfbox+
-command, which issues a warning and typesets its argument
-inside a \verb+\mbox+ (and thus no frame is drawn).
-Users can alter the behaviour of \verb+\fbox+ in non-display mode by
-redefining \verb+\textfbox+.
+Similarly, the boxing-with-frame commands \verb+\fbox+ and
+\verb+\framebox+ are recognized.  Here both, long and short forms
+refer to class~\verb+framebox+, which also can be redefined by the
+user.
 
-
+\smallskip
 
 Boxes can be saved for latter usage by storing them in {\em bins}.
 New bins are defined by \verb+\newsavebox{+{\it cmd}\verb+}+.
@@ -5528,8 +5521,10 @@ optional arguments.
 The \verb+\rule+ commands translate to a \html{} horizontal rule
 (\verb+<HR>+)  regardless of its arguments.
 
+\smallskip
 
-All other box-related commands do not exist.
+No other box-related commands are implemented.
+
 
 \section{Pictures and Colours}
 

--- a/html/hevea.hva
+++ b/html/hevea.hva
@@ -383,6 +383,50 @@
 \newcommand{\raggedleft}{\@insert{div}{\envclass@attr{flushright}}}
 \newcommand{\raggedright}{\@insert{div}{\envclass@attr{flushleft}}}
 \newcommand{\rule}[3][]{\@printHR{}{}}%
+%%special boxes
+\newstyle{.parbox}{
+  box-sizing: border-box;
+  display: inline-block;
+  text-indent: 0;
+}
+\def\@parbox@alignment@spec@bottom{b}
+\def\@parbox@alignment@spec@center{c}
+\def\@parbox@alignment@spec@top{t}
+\RenewcommandHtml{\parbox}[3][]{%
+  \def\@align{middle}%
+  \def\@align@spec{#1}%
+  \ife#1%
+    \relax
+  \else
+    \ifx\@parbox@alignment@spec@center
+      \relax
+    \else
+      \ifx\@align@spec\@parbox@alignment@spec@bottom
+        \def\@align{text-bottom}%
+      \else
+        \ifx\@align@spec\@parbox@alignment@spec@top
+          \def\@align{text-top}%
+        \else
+          \hva@warn{parbox: unknown alignment}%
+        \fi
+      \fi
+    \fi
+  \fi
+  \@open{span@inline@block}{class="parbox" style="vertical-align:\@align;width:\css@length{#2}"}%
+  #3%
+  \@close{span@inline@block}%
+}
+\RenewcommandHtml{\@raisebox}[4]{%
+  \def\@height{max-content}%
+  \ife#2%
+    \relax
+  \else
+    \def\@height{\css@length{#2}}%
+  \fi
+  \@open{div}{style="display:inline-block;height:\@height;transform:translateY(calc(0pt - ( \css@length{#1} )))"}%
+  #4%
+  \@close{div}%
+}
 %For figure & tables
 \newcommand{\@open@quote}[1]{\@open{blockquote}{#1}}
 \newcommand{\@close@quote}{\@close{blockquote}}

--- a/html/hevea.hva
+++ b/html/hevea.hva
@@ -545,14 +545,80 @@
 %   Redefining \fbox of latexcommon.hva	         		%
 %   Here we can use HTML primitives				%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\newstyle{.boxed}{border:1px solid black}
-\newstyle{.textboxed}{border:1px solid black}
-\NewcommandHtml{\@@boxed}[1]
-{\@start@text\@open{table}{class="boxed"}\@open{tr}{}\@open{td}{}%
-#1%
-\@close{td}\@close{tr}\@close{table}\@end@text}
-\NewcommandHtml{\@boxed}[1]{{\@styleattr{span}{class="textboxed"}#1}}
-\RenewcommandHtml{\fbox}{\DisplayChoose\@@boxed\@boxed}
+\newstyle{.lrbox}{box-sizing:border-box;display:inline-block;overflow:visible;white-space:nowrap;}
+\newstyle{.center-lrbox}{display:inline-block;margin-left:50\%;transform:translateX(-50\%);}
+\newstyle{.makebox}{}
+\newstyle{.framebox}{border:1px solid black;padding:0.25em;}
+\def\@lrbox@alignment@spec@center{c}
+\def\@lrbox@alignment@spec@left{l}
+\def\@lrbox@alignment@spec@right{r}
+\newcommand{\@lr@box@attr}[2]{%
+  \ife#1%
+    \relax
+  \else
+    \def\@flush@alignment{}%
+    \ife#2%
+      \relax
+    \else
+      \def\@alignment@spec{#2}%
+      \ifx\@alignment@spec\@lrbox@alignment@spec@center
+        \relax
+      \else
+        \ifx\@alignment@spec\@lrbox@alignment@spec@left
+          \def\@flush@alignment{text-align:left;}%
+        \else
+          \ifx\@alignment@spec\@lrbox@alignment@spec@right
+            \def\@flush@alignment{text-align:right;direction:rtl;}%
+          \else
+            \hva@warn{unknown lr-box alignment}%
+          \fi
+        \fi
+      \fi
+    \fi
+    style="width:#1;\@flush@alignment"%
+  \fi
+}
+\newenvironment{@center@lrbox}%
+  {\@open{span@inline@block}{class="center-lrbox"}}%
+  {\@close{span@inline@block}}
+\newcommand{\@conditionally@center@lrbox@begin}[2]{%
+  \ife#1
+    \relax
+  \else
+    \ife#2%
+      \@center@lrbox
+    \else
+      \def\@alignment@spec{#2}%
+      \ifx\@alignment@spec\@lrbox@alignment@spec@center
+        \@center@lrbox
+      \fi
+    \fi
+  \fi
+}
+\newcommand{\@conditionally@center@lrbox@end}[2]{%
+  \ife#1
+    \relax
+  \else
+    \ife#2%
+      \end@center@lrbox
+    \else
+      \def\@alignment@spec{#2}%
+      \ifx\@alignment@spec\@lrbox@alignment@spec@center
+        \end@center@lrbox
+      \fi
+    \fi
+  \fi
+}
+\newcommand{\@lr@box}[4]{%
+  \@open{span@inline@block}{\@lr@box@attr{#1}{#2} class="lrbox #4"}%
+  \@conditionally@center@lrbox@begin{#1}{#2}%
+  \textnormal{#3}%
+  \@conditionally@center@lrbox@end{#1}{#2}%
+  \@close{span@inline@block}%
+}
+\RenewcommandHtml{\@makebox}[3]{\@lr@box{#1}{#2}{#3}{makebox}}
+\RenewcommandHtml{\@framebox}[3]{\@lr@box{#1}{#2}{#3}{framebox}}
+\RenewcommandHtml{\fbox}[1]{\framebox{#1}}
 %%Style of bars
 \def\@barsz{2px}
 \def\@@barsz{4px}%2 x

--- a/html/hevea.hva
+++ b/html/hevea.hva
@@ -575,7 +575,7 @@
         \fi
       \fi
     \fi
-    style="width:#1;\@flush@alignment"%
+    style="width:\css@length{#1};\@flush@alignment"%
   \fi
 }
 \newenvironment{@center@lrbox}%

--- a/latexcommon.hva
+++ b/latexcommon.hva
@@ -360,6 +360,8 @@
 \def\@end@document@seen{NO}%
 \AtEndDocument{\gdef\@end@document@seen{OK}}
 %%% Boxes
+\newcommand{\@makebox}[3]{\hva@warn{makebox}\mbox{#3}}
+\newcommand{\@framebox}[3]{\hva@warn{framebox}\fbox{#3}}
 \newcommand{\textfbox}[1]{\hva@warn{\fbox in text}\mbox{#1}}
 \def\fbox#1{%
 \ifdisplay\begin{tabular}{|c|}\hline#1\end{array}\else

--- a/latexcommon.hva
+++ b/latexcommon.hva
@@ -362,6 +362,8 @@
 %%% Boxes
 \newcommand{\@makebox}[3]{\hva@warn{makebox}\mbox{#3}}
 \newcommand{\@framebox}[3]{\hva@warn{framebox}\fbox{#3}}
+\newcommand{\@raisebox}[4]{\hva@warn{raisebox}\mbox{#4}}
+\newcommand{\parbox}[3][]{\hva@warn{parbox}#3}
 \newcommand{\textfbox}[1]{\hva@warn{\fbox in text}\mbox{#1}}
 \def\fbox#1{%
 \ifdisplay\begin{tabular}{|c|}\hline#1\end{array}\else

--- a/package.ml
+++ b/package.ml
@@ -404,6 +404,16 @@ def "\\framebox" (latex_pat ["" ; ""] 3)
 ;;
 
 
+def_code "\\raisebox"
+  (fun lexbuf ->
+    let raise_len = get_prim_arg lexbuf in
+      let hght = get_prim_opt "" lexbuf in
+        let dpth = get_prim_opt "" lexbuf in
+          let text = get_prim_arg lexbuf in
+            scan_this main ("\\@raisebox{" ^ raise_len ^ "}{" ^ hght ^ "}{" ^ dpth ^ "}{" ^ text ^ "}"))
+;;
+
+
 (***********************)
 (* Special definitions *)
 (***********************)

--- a/package.ml
+++ b/package.ml
@@ -398,9 +398,9 @@ def_code
 (* A few subst definitions, with 2 optional arguments *)
 
 def "\\makebox" (latex_pat ["" ; ""] 3)
-    (Subst ["\\hva@warn{makebox}\\mbox{#3}"]) ;
+    (Subst ["\\@makebox{#1}{#2}{#3}"]) ;
 def "\\framebox" (latex_pat ["" ; ""] 3)
-    (Subst ["\\hva@warn{framebox}\\fbox{#3}"])
+    (Subst ["\\@framebox{#1}{#2}{#3}"])
 ;;
 
 


### PR DESCRIPTION
Add `\makebox[WIDTH][ALIGN]{TEXT}` and `\framebox[WIDTH][ALIGN]{TEXT}`
with most of their LaTeX functionality.  Base the new definition
of `\fbox` on `\framebox`.  Alignment type `s` is unimplemented.

Macro `\mbox` is not touched.

Here is a demo-document:

```latex
\documentclass{article}

\usepackage{hevea}

\newenvironment{markerbar}{\begingroup$|$}{$|$\endgroup}

\begin{document}
\section{Text Mode}

\begin{itemize}
\item \texttt{\textbackslash mbox}:
  \mbox{typeset text in LR-mode};

\item \texttt{\textbackslash makebox}
  \begin{itemize}
  \item without optional arguments:
    \begin{markerbar}\makebox{text in LR-mode}\end{markerbar};
  \item with fixed width:
    \begin{markerbar}\makebox[12em]{text in LR-mode}\end{markerbar};
    \begin{markerbar}\makebox[12em][c]{text in LR-mode}\end{markerbar};
  \item fixed width, left-aligned:
    \begin{markerbar}\makebox[12em][l]{text in LR-mode}\end{markerbar};
  \item fixed width, right-aligned:
    \begin{markerbar}\makebox[12em][r]{text in LR-mode}\end{markerbar};
  \item fixed width, too wide:
    \begin{markerbar}\makebox[1em]{CENTERED}\end{markerbar};
  \item fixed width, too wide, left-aligned:
    \begin{markerbar}\makebox[1em][l]{LEFT-ALIGNED}\end{markerbar};
  \item fixed width, too wide, right-aligned:
    \begin{markerbar}\makebox[1em][r]{RIGHT-ALIGNED}\end{markerbar};
  \end{itemize}

\item \texttt{\textbackslash fbox}:
  \fbox{typeset text in LR-mode and frame it};

\item \texttt{\textbackslash framebox}
  \begin{itemize}
  \item without optional arguments: \framebox{text in LR-mode};
  \item with fixed width: \framebox[12em]{text in LR-mode};  \framebox[12em][c]{text in LR-mode};
  \item fixed width, left-aligned: \framebox[12em][l]{text in LR-mode};
  \item fixed width, right-aligned: \framebox[12em][r]{text in LR-mode};
  \item fixed width, too wide: \framebox[1em]{CENTERED};
  \item fixed width, too wide, left-aligned: \framebox[1em][l]{LEFT-ALIGNED};
  \item fixed width, too wide, right-aligned: \framebox[1em][r]{RIGHT-ALIGNED};
  \end{itemize}
\end{itemize}


\section{Framebox Nesting}

\begin{itemize}
\item \texttt{\textbackslash fbox}:
  \fbox{E\fbox{F\fbox{G\fbox{H\fbox{I\fbox{J\fbox{K\fbox{L\fbox{M}N}O}P}Q}R}S}T}U}

\item \texttt{\textbackslash framebox}:
  \framebox{E\framebox{F\framebox{%
        G\framebox{H\framebox{I\framebox{%
              J\framebox[9em][l]{K\framebox[5em][r]{L\framebox[2em][c]{M}N}O}P%
            }Q}R}S%
      }T}U}
\end{itemize}


\section{Math Mode}

Check whether \texttt{\textbackslash normalfont} works inside of a
math environment:
$r_{\mathrm{s}} c^2 = 2 G M\textnormal{ with Schwarzschild radius}~r_{\mathrm{s}}$.

\begin{equation}
    E = \hbar \omega\quad\makebox{de~Broglie}\ \mbox{I}
\end{equation}

\[
    p = \hbar k\quad\framebox{de~Broglie}\ \fbox{II}
\]

\begin{eqnarray}
  E  &  =  &
  \frac{p^2}{2m}  \\
  E  &  \rightarrow  &
  i \hbar \frac{\partial}{\partial{}t}\ \framebox{N.~Bohr}, \makebox{M.~Planck: $\hbar$}  \\
  p  &  \rightarrow  &
  -i \hbar \frac{\partial}{\partial{}x}\ \framebox{N.~Bohr}, \makebox{M.~Planck: $\hbar$}  \\
  -\frac{1}{2m} \frac{\partial^2}{\partial{}x^2} \Psi(x, t)  &  =  &
  i \frac{\partial}{\partial{}t}\Psi(x, t)\quad\makebox{Schr\"odinger Equ.}
\end{eqnarray}
\end{document}
```

Please compare the rendering of LaTeX to the Hevea output.  Overprinting effects of
the demo will look ugly.  This is _intentional_ as we test whether the HTML output
strictly keeps the text baselines even and obeys the ALIGN specifiers where they stack
up against the default left-to-right direction.
