### PR TITLE
Document CSS class `horizontal-rule`.

### DIFF
--- a/doc/text.tex
+++ b/doc/text.tex
@@ -2733,53 +2733,64 @@ break or the internal display may get cancelled.
 \index{"@fontsize@\texttt{\char92"@fontsize}|defocc}
 \index{"@fontcolor@\texttt{\char92"@fontcolor}|defocc}
 It is important to notice that primitive arguments \emph{are}
-processed (except for the \verb+\@print+ primitive, and for some of
-the basic style primitives). Thus,
-some characters cannot be given directly (e.g. \verb+#+ and
-\verb+%+ must be given as \verb+\#+ and \verb+\%+).
+processed (except for the \verb+\@print+~primitive, and for some of
+the basic style primitives).  Thus, some characters cannot be given
+directly (e.g. \verb+#+ and \verb+%+ must be given as \verb+\#+ and
+\verb+\%+).
+
 \begin{description}
-\item[{\tt\char92 @print\char123}{\it text}{\tt\char125}]
-Echo \textit{text} verbatim. As a consequence use only ascii
-in \textit{text}.
-\item[{\tt\char92 @getprint\char123}{\it text}{\tt\char125}]
-Process \textit{text} using a special output mode that strips off
-\html~tags. This macro is the one to use for processed attributes of
-\html~tags.
+\item[{\tt\char92 @print\char123}{\it text}{\tt\char125}] Echo
+  \textit{text} verbatim.  As a consequence use only ASCII in
+  \textit{text}.
+
+\item[{\tt\char92 @getprint\char123}{\it text}{\tt\char125}] Process
+  \textit{text} using a special output mode that strips off
+  \html~tags.  This macro is the one to use for processed attributes
+  of \html~tags.
+
 \item[{\tt\char92 @hr[}{\it attr}{\tt]\char123}{\it
-width}{\tt\char125\char123}{\it height}{\tt\char125}]
-Output an \html{} horizontal rule, \textit{attr} is attributes given
-directly (e.g. \verb+SIZE=3 HOSHADE+), while \textit{width} and
-\textit{height} are length arguments given in the \LaTeX{} style
-(e.g. \verb+2pt+ or~\verb+.5\linewidth+).
-\item[{\tt\char92 @print@u\char123}{\it n}{\tt\char125}]
-Output the (Unicode) character ``\textit{n}'', which can
-be given either as a decimal number or an hexadecimal number prefixed
-by ``\texttt{X}''.
+    width}{\tt\char125\char123}{\it height}{\tt\char125}] Output an
+  \verb+hr+~element, this is, a horizontal rule.  Optional
+  argument~\textit{attr} are attributes passed on directly
+  (e.g. \verb+size=3 noshade+), while \textit{width} and
+  \textit{height} are length arguments given in \LaTeX~style
+  (e.g. \verb+2pt+ or~\verb+.5\linewidth+).
+
+  Users can style the rules generated with \verb+\@hr+ by overriding
+  class~\verb+horizontal-rule+.
+
+\item[{\tt\char92 @print@u\char123}{\it n}{\tt\char125}] Output
+  Unicode character~``\textit{n}'' which can be given either as a
+  decimal number or as a hexadecimal number prefixed with
+  ``\texttt{X}''.
 
 \item[{\tt\char92 @open\char123}{\it block}{\tt\char125\char123}{\it
-attributes}{\tt\char125}]
-Open \html{} block-level element \textit{block} with attributes
-\textit{attributes}. The block name \textit{block} \textbf{must} be
-lowercase.
-As a special case \textit{block} may be the empty string, then a \html{}
-\emph{group} is opened.  Argument~\textit{block} cannot be \verb+p+; use
- \verb+\@open@par+ to open a paragraph element.
-\item[{\tt\char92 @close\char123}{\it block}{\tt\char125}]
-Close \html{} block-level element \textit{block}.
-Note that \verb+\@open+ and \verb+\@close+ must be properly balanced.
+    attributes}{\tt\char125}] Open \html{} block-level element
+  \textit{block} with attributes \textit{attributes}.  The block name
+  \textit{block} \textbf{must} be lowercase.
+
+  As a special case, \textit{block} may be the empty string, then an
+  \html~\emph{group} is opened.  Argument~\textit{block} cannot be
+  \verb+p+; use \verb+\@open@par+ to open a paragraph element.
+
+\item[{\tt\char92 @close\char123}{\it block}{\tt\char125}] Close
+  \html{} block-level element~\textit{block}.  Note that \verb+\@open+
+  and \verb+\@close+ must be properly balanced.
+
 \item[{\tt\char92 @open@par[}{\it attributes}{\tt ]}] Open a paragraph
-block element, which optionally gets attributes~\textit{attributes}.
-\item[{\tt\char92 @close@par}]  Close a paragraph block element.
-Note that \verb+\@open@par+ and \verb+\@close@par+ also must be
-properly balanced.
-\item[{\tt\char92 @out@par\char123}{\it arg}{\tt\char125}]
-If occurring inside a \verb+p+ element,
-that is if a \verb+<p>+ opening tag is active,
-\verb+\@out@par+  first closes it (by emitting \verb+</p>+),
-then formats \textit{arg}, and then re-open a \verb+p+ element.
-Otherwise \verb+\@out@par+ simply formats \textit{arg}.
-This command is adequate when
-formatting \textit{arg} produces block-level elements.
+  block element, which optionally gets attributes~\textit{attributes}.
+
+\item[{\tt\char92 @close@par}] Close a paragraph block element.  Note
+  that \verb+\@open@par+ and \verb+\@close@par+ also must be properly
+  balanced.
+
+\item[{\tt\char92 @out@par\char123}{\it arg}{\tt\char125}] If
+  occurring inside a \verb+p+~element, that is, if a \verb+<p>+
+  opening tag is active, \verb+\@out@par+ first closes it (by emitting
+  \verb+</p>+), formats \textit{arg}, and then re-opens a \verb+p+
+  element.  Otherwise, \verb+\@out@par+ simply formats \textit{arg}.
+  This command is adequate when formatting \textit{arg} produces
+  block-level elements.
 \end{description}
 
 \index{text-level elements}

--- a/html.ml
+++ b/html.ml
@@ -639,7 +639,7 @@ let make_hline w noborder =
   if noborder then begin
     new_row ();
     if not (flags.in_math && !Parse_opts.mathml) then begin
-      open_direct_cell "class=\"hbar\"" w ;
+      open_direct_cell "class=\"horizontal-rule\"" w ;
       close_cell ""
     end else begin
       open_cell hline_format w 0 false;

--- a/html/hevea.hva
+++ b/html/hevea.hva
@@ -558,27 +558,27 @@
 \def\@@barsz{4px}%2 x
 \def\@@@barsz{6px}%3 x
 \def\@@@@barsz{8px}%3 x
-\newstyle{.vbar}
+\newstyle{.vertical-rule}
 {border:none;width:\@barsz;background-color:black;}
-\newstyle{.hbar}
+\newstyle{.horizontal-rule}
 {border:none;height:\@barsz;width:100\%;background-color:black;}
 \newstyle{.hfill}
 {border:none;height:1px;width:200\%;background-color:black;}
 %%%Bars with HR
 \newcommand{\@hfill}{{\@nostyle\@print{<hr class="hfill"}}}
 \newcommand{\@hbar}[1][]
-{{\@clearstyle\def\@tmp{#1}\@print{<hr class="hbar"}%
+{{\@clearstyle\def\@tmp{#1}\@print{<hr class="horizontal-rule"}%
 \@getprint{\ifx\@tmp\@empty\else{} #1\fi}\@print{>}}}
 \newcommand{\@vbar}[1][]
-{{\@clearstyle\def\@tmp{#1}\@print{<hr class="vbar"}%
+{{\@clearstyle\def\@tmp{#1}\@print{<hr class="vertical-rule"}%
 \@getprint{\ifx\@tmp\@empty\else{} #1\fi}\@print{>}}}
 %%Bars with div
 \newcommand{\@@hbar}[1][]
 {{\@clearstyle\def\@tmp{#1}%
-\@open{div}{class="hbar"\ifx\@tmp\@empty\else{} #1\fi}\@force{div}}}
+\@open{div}{class="horizontal-rule"\ifx\@tmp\@empty\else{} #1\fi}\@force{div}}}
 \newcommand{\@@vbar}[1][]
 {{\@clearstyle\def\@tmp{#1}%
-\@open{div}{class="vbar"\ifx\@tmp\@empty\else{} #1\fi}\@force{div}}}
+\@open{div}{class="vertical-rule"\ifx\@tmp\@empty\else{} #1\fi}\@force{div}}}
 %%Style of paragraphs
 \ifverbd\newstyle{p}{border:1px solid gray}\fi
 \ifverbd\newstyle{div}{border:1px dotted gray}\fi

--- a/htmlCommon.ml
+++ b/htmlCommon.ml
@@ -1611,7 +1611,7 @@ let horizontal_line attr width height =
     | Default, Default ->
        put_char '>'
     | _, _ ->
-       put " class=\"hbar\" style=\"";
+       put " class=\"horizontal-rule\" style=\"";
        put_length "width:" width;
        if width <> Default then put ";";
        put_length "height:" height;
@@ -1620,7 +1620,7 @@ let horizontal_line attr width height =
   close_block GROUP
 
 let line_in_table () =
-  put "<hr class=\"hbar\">";
+  put "<hr class=\"horizontal-rule\">";
   flags.vsize <- flags.vsize - 1
 
 let freeze f =

--- a/htmlMath.ml
+++ b/htmlMath.ml
@@ -451,7 +451,7 @@ let insert_vdisplay open_fun =
 
 let line_in_vdisplay_row () =
   open_block TR "" ;
-  open_block TD "class=\"hbar\"" ;
+  open_block TD "class=\"horizontal-rule\"" ;
   (*
     close_mods () ;
     line_in_table () ;

--- a/iso-symb.hva
+++ b/iso-symb.hva
@@ -636,7 +636,7 @@
 {\setcounter{@c}{(#1-5)*2}%
 \@open{TABLE}{style="border-spacing:0" class="cellpadding0"}%
 \@open{TR}{}\@open{TD}{ALIGN="right"}%
-\@open{DIV}{CLASS="vbar" STYLE="height:\arabic{@c}em;"}\@force{DIV}%
+\@open{DIV}{CLASS="vertical-rule" STYLE="height:\arabic{@c}em;"}\@force{DIV}%
 \@close{TD}\@close{TR}%
 \@open{TR}{}\@open{TD}{}%
 {\Huge#2}%

--- a/winfonts.hva
+++ b/winfonts.hva
@@ -2,7 +2,7 @@
 %%vert
 \newcommand{\@vert@table}[2][\@@barsz]
 {\setcounter{@c}{(#2)}%
-\@open{div}{class="vbar" style="height:\arabic{@c}em; margin:0ex #1;"}\@force{div}}%
+\@open{div}{class="vertical-rule" style="height:\arabic{@c}em; margin:0ex #1;"}\@force{div}}%
 \renewcommand{\csname\delim@name{\vert}\endcsname}[1]
 {\@vert@table{#1}}%
 \renewcommand{\csname\delim@name{|}\endcsname}[1]
@@ -32,7 +32,7 @@
 {\@open{tr}{}\@open{td}{class="bracell"#1}%
 #2\@close{td}\@close{tr}}
 \newcommand{\@hbarcell}[1]
-{\@open{tr}{}\@open{td}{class="bracell hbar" style="width:#1;"}%
+{\@open{tr}{}\@open{td}{class="bracell horizontal-rule" style="width:#1;"}%
 \@force{td}\@close{tr}}
 \newcommand{\@leftsqbra@table}[1]
 {\setcounter{@c}{(#1)}%
@@ -118,7 +118,7 @@
 {\setcounter{@c}{(#1)}%
 \@open{table}{class="delim"}%
 \@bracell[ \win@center@cell]
-{\@open{div}{class="vbar" style="height:\arabic{@c}em;"}\@force{div}}%
+{\@open{div}{class="vertical-rule" style="height:\arabic{@c}em;"}\@force{div}}%
 \@bracell{\@print@u{X25BC}}%
 \@close{table}}%
 \newcommand{\@updownarrow@table}[1]
@@ -126,7 +126,7 @@
 \@open{table}{class="delim"}%
 \@bracell{\@print@u{X25B2}}%
 \@bracell[ \win@center@cell]
-{\@open{div}{class="vbar" style="height:\arabic{@c}em;"}\@force{div}}%
+{\@open{div}{class="vertical-rule" style="height:\arabic{@c}em;"}\@force{div}}%
 \@bracell{\@print@u{X25BC}}%
 \@close{table}}%
 \renewcommand{\csname\delim@name{\uparrow}\endcsname}[1]


### PR DESCRIPTION
In the aftermath of P/R "Add some missing length units" (#44) Luc suggested
to document the CSS class that controls the appearance of horizontal bars
generated with the internal (and documented) macro `\@hr`.  We agreed on
renaming the class to `horizontal-rule` before exposing it to the Hevea users.

For consistency class `vertical-rule` has been renamed, too.
