### PR TITLE
Remove `height` and `width` from class `horizontal-rule`

### DIFF
--- a/html.ml
+++ b/html.ml
@@ -639,7 +639,7 @@ let make_hline w noborder =
   if noborder then begin
     new_row ();
     if not (flags.in_math && !Parse_opts.mathml) then begin
-      open_direct_cell "class=\"horizontal-rule\"" w ;
+      open_direct_cell "class=\"hrule\"" w ;
       close_cell ""
     end else begin
       open_cell hline_format w 0 false;

--- a/html/hevea.hva
+++ b/html/hevea.hva
@@ -668,12 +668,9 @@
 \def\@@barsz{4px}%2 x
 \def\@@@barsz{6px}%3 x
 \def\@@@@barsz{8px}%3 x
-\newstyle{.vertical-rule}
-{border:none;width:\@barsz;background-color:black;}
-\newstyle{.horizontal-rule}
-{border:none;height:\@barsz;width:100\%;background-color:black;}
-\newstyle{.hfill}
-{border:none;height:1px;width:200\%;background-color:black;}
+\newstyle{.vertical-rule}{border:none;width:\@barsz;background-color:black;}
+\newstyle{.horizontal-rule}{border:none;background-color:black;}
+\newstyle{.hfill}{border:none;height:1px;width:200\%;background-color:black;}
 %%%Bars with HR
 \newcommand{\@hfill}{{\@nostyle\@print{<hr class="hfill"}}}
 \newcommand{\@hbar}[1][]

--- a/html/hevea.hva
+++ b/html/hevea.hva
@@ -670,22 +670,37 @@
 \def\@@@@barsz{8px}%3 x
 \newstyle{.vertical-rule}{border:none;width:\@barsz;background-color:black;}
 \newstyle{.horizontal-rule}{border:none;background-color:black;}
+\newstyle{.hrule}{border:none;height:\@barsz;width:100\%;background-color:black;}
 \newstyle{.hfill}{border:none;height:1px;width:200\%;background-color:black;}
 %%%Bars with HR
 \newcommand{\@hfill}{{\@nostyle\@print{<hr class="hfill"}}}
-\newcommand{\@hbar}[1][]
-{{\@clearstyle\def\@tmp{#1}\@print{<hr class="horizontal-rule"}%
-\@getprint{\ifx\@tmp\@empty\else{} #1\fi}\@print{>}}}
-\newcommand{\@vbar}[1][]
-{{\@clearstyle\def\@tmp{#1}\@print{<hr class="vertical-rule"}%
-\@getprint{\ifx\@tmp\@empty\else{} #1\fi}\@print{>}}}
+\newcommand{\@hbar}[1][]{%
+  {\@clearstyle
+   \def\@tmp{#1}%
+   \@print{<hr class="horizontal-rule"}%
+   \@getprint{\ifx\@tmp\@empty\else{} #1\fi}%
+   \@print{>}}%
+}
+\newcommand{\@vbar}[1][]{%
+  {\@clearstyle
+   \def\@tmp{#1}%
+   \@print{<hr class="vertical-rule"}%
+   \@getprint{\ifx\@tmp\@empty\else{} #1\fi}%
+   \@print{>}}%
+}
 %%Bars with div
-\newcommand{\@@hbar}[1][]
-{{\@clearstyle\def\@tmp{#1}%
-\@open{div}{class="horizontal-rule"\ifx\@tmp\@empty\else{} #1\fi}\@force{div}}}
-\newcommand{\@@vbar}[1][]
-{{\@clearstyle\def\@tmp{#1}%
-\@open{div}{class="vertical-rule"\ifx\@tmp\@empty\else{} #1\fi}\@force{div}}}
+\newcommand{\@@hbar}[1][]{%
+  {\@clearstyle
+   \def\@tmp{#1}%
+   \@open{div}{class="horizontal-rule"\ifx\@tmp\@empty\else{} #1\fi}%
+   \@force{div}}%
+}
+\newcommand{\@@vbar}[1][]{%
+  {\@clearstyle
+   \def\@tmp{#1}%
+   \@open{div}{class="vertical-rule"\ifx\@tmp\@empty\else{} #1\fi}%
+   \@force{div}}%
+}
 %%Style of paragraphs
 \ifverbd\newstyle{p}{border:1px solid gray}\fi
 \ifverbd\newstyle{div}{border:1px dotted gray}\fi

--- a/htmlCommon.ml
+++ b/htmlCommon.ml
@@ -1620,7 +1620,7 @@ let horizontal_line attr width height =
   close_block GROUP
 
 let line_in_table () =
-  put "<hr class=\"horizontal-rule\">";
+  put "<hr class=\"hrule\">";
   flags.vsize <- flags.vsize - 1
 
 let freeze f =

--- a/htmlMath.ml
+++ b/htmlMath.ml
@@ -451,7 +451,7 @@ let insert_vdisplay open_fun =
 
 let line_in_vdisplay_row () =
   open_block TR "" ;
-  open_block TD "class=\"horizontal-rule\"" ;
+  open_block TD "class=\"hrule\"" ;
   (*
     close_mods () ;
     line_in_table () ;


### PR DESCRIPTION
Alternative title: _"The Optimizer Strikes Back!"_

The current definition of CSS class `horizontal-rule` sets both
`height` and `width`.  Macro `\@hr` uses class `horizontal-rule`,
but overrides `height` and `width` with a `style` attribute to
control the shape of the rule as requested by the macros'
actual arguments.

If the optimizer decides to hoist this `style` and
convert it to a CSS class the precedence rules change:
Classes are applied in their order of definition.  The optimizer
sorts all classes into alphabetical order and uses the prefix `c`
for its own classes.  That way the style hoisted into class `c###`
always ends up before class `horizontal-rule` and the style's
`height` and `width` thus are shadowed.

The last item of the following example generates different
horizontal rules depending whether translated with or
without `-O`.

```latex
\documentclass{article}
\usepackage{hevea}
\begin{document}
  \begin{itemize}
  \item 10em/0.0625em: \@hr{10em}{0.0625em}
  \item 1em/1em: \@hr{1em}{1em}
  \item 0.0625em/3em: \@hr{0.0625em}{3em}
  \item 50\% linewidth/2pt: \@hr{0.5\linewidth}{2pt}
  \item $2\times$ 5em/5pt: \@hr{5em}{5pt}. \@hr{5em}{5pt}.
  \end{itemize}
\end{document}
```

This P/R suggests to drop both `height` and `width` from
class `horizontal-rule` to recover consistent behavior.
