### PR TITLE
Fix and modernize contents of `head` (according to vnu checker)

### DIFF
--- a/chapterbib.hva
+++ b/chapterbib.hva
@@ -1,8 +1,8 @@
 \let\chapterbib@include\include
 \newcounter{chap@included}
 \newcommand{\maketocbibitem}{}
-\newcommand{\@sectionbib@maketocbibitem}{\@auxdowrite{\@print{\@addcontentsline{htoc}}\{0\}\{\@print{\ahrefloc}\{bib:chap\thechap@included\}\{\refname{}\}\}\@print{
-}}}
+\newcommand{\@sectionbib@maketocbibitem}{%
+  \@auxdowrite{\@print{\@addcontentsline{htoc}}\{0\}\{\@print{\ahrefloc}\{bib:chap\thechap@included\}\{\refname{}\}\}\@print@endline{}}}
 \renewcommand{\include}[1]
 {\stepcounter{chap@included}%
 \def\chapterbib@include@name{#1}%

--- a/cut.mll
+++ b/cut.mll
@@ -859,8 +859,7 @@ and collect_header = parse
     end}
 | '\n'? "<title" [^'>']* '>'
     {skip_title lexbuf ; collect_header lexbuf}
-| "<style" blank+ "type" blank* '=' blank* '"' "text/css" '"' blank* '>'
-    '\n'?
+| "<style>" '\n'?
     {collect_style lexbuf ;  collect_header lexbuf}
 | _ as lxm
     {adjoin_to_header_char lxm;
@@ -869,7 +868,7 @@ and collect_header = parse
 and repeat_header = parse
 | "</head>" as lxm
     {put (!link_style) ; put lxm }
-| "<style" blank+ "type" blank* '=' blank* '"' "text/css" '"' blank* '>'
+| "<style>"
     {skip_style lexbuf ; repeat_header lexbuf}
 | _ as lxm
     {put_char lxm ; repeat_header lexbuf}

--- a/doc/text.tex
+++ b/doc/text.tex
@@ -2726,6 +2726,7 @@ break or the internal display may get cancelled.
 
 
 \index{"@print@\texttt{\char92"@print}|defocc}
+\index{"@print"@endline@\texttt{\char92"@print"@endline}|defocc}
 \index{"@getprint@\texttt{\char92"@getprint}|defocc}
 \index{"@print"@u@\texttt{\char92"@print"@u}|defocc}
 \index{"@hr@\texttt{\char92"@hr}|defocc}
@@ -2739,7 +2740,7 @@ break or the internal display may get cancelled.
 \index{"@fontsize@\texttt{\char92"@fontsize}|defocc}
 \index{"@fontcolor@\texttt{\char92"@fontcolor}|defocc}
 It is important to notice that primitive arguments \emph{are}
-processed (except for the \verb+\@print+~primitive, and for some of
+processed (except for the \verb+\@print+~primitives, and for some of
 the basic style primitives).  Thus, some characters cannot be given
 directly (e.g. \verb+#+ and \verb+%+ must be given as \verb+\#+ and
 \verb+\%+).
@@ -2748,6 +2749,9 @@ directly (e.g. \verb+#+ and \verb+%+ must be given as \verb+\#+ and
 \item[{\tt\char92 @print\char123}{\it text}{\tt\char125}] Echo
   \textit{text} verbatim.  As a consequence use only ASCII in
   \textit{text}.
+
+\item[{\tt\char92 @print@endline\char123}{\it text}{\tt\char125}] Same
+  as \verb+\@print+ but appends a newline character to the output.
 
 \item[{\tt\char92 @getprint\char123}{\it text}{\tt\char125}] Process
   \textit{text} using a special output mode that strips off

--- a/html/hevea.hva
+++ b/html/hevea.hva
@@ -12,7 +12,9 @@
 % Linking to external style sheets
 \newtokens{\css@link}%
 \newcommand{\addcssfile}[1]{\addtokens{\css@link}{#1}}%
-\newcommand{\loadcssfile}[1]{\addcssfile{\@print{<}\@getprint{link rel="stylesheet" type=\char34 text/css\char34\@print{ }href=\char34#1\char34\char62\@print@endline{}}}}%
+\newcommand{\loadcssfile}[1]{%
+  \addcssfile{\@print{<link rel="stylesheet" type="text/css" href="}\@getprint{#1}\@print@endline{">}}%
+}
 %%%%%%
 % Styles definition in the <HEAD> element
 \newtokens{\hevea@css}%
@@ -264,23 +266,32 @@
 %%%%%%%%%%%% Language translation
 \input{html/lang.hva}
 %%% Environment document.
-\newcommand{\@charset}{US-ASCII}
-\newcommand{\@def@charset}[1]
-{\renewcommand{\@charset}{#1}\@set@out@translator{mappings/#1.map}}
+\newcommand{\@charset}{utf-8}
+\newcommand{\@def@charset}[1]{\renewcommand{\@charset}{#1}\@set@out@translator{mappings/#1.map}}
 \newcommand{\@bodyargs}{}
 \newcommand{\@htmlargs}{}
-\newcommand{\@meta}
-{\@print{<meta http-equiv="Content-Type" content="text/html; charset=}%
-\@getprint{\@charset}%
-\@print{">
-<meta name="generator" content="hevea }%
-\@getprint{\usebox{\@heveaversion}}\@print@endline{">}%
-\ife\hevea@css\else
-\ifexternalcss\loadcssfile{\hva@dump@css}\else
-\@print{<style type="text/css">}
-\hevea@css\@print@endline{</style>}\fi\fi
-\ife\css@link\else\css@link\fi
-\undef\hevea@css\undef\newstyle}
+\newcommand{\@meta}{%
+  \@print{<meta charset="}\@getprint{\@charset}\@print@endline{">}%
+  \@print{<meta name="generator" content="hevea }\@getprint{\usebox{\@heveaversion}}\@print@endline{">}%
+  \ife\hevea@css
+    \relax
+  \else
+    \ifexternalcss
+      \loadcssfile{\hva@dump@css}%
+    \else
+      \@print@endline{<style>}%
+      \hevea@css
+      \@print@endline{</style>}%
+    \fi
+  \fi
+  \ife\css@link
+    \relax
+  \else
+    \css@link
+  \fi
+  \undef\hevea@css
+  \undef\newstyle
+}
 \newenvironment{document}{%
 \@end{document}%
 \@atbegindocument%
@@ -294,8 +305,8 @@
 \@notags{\begin{@norefs}\let\@print@u\@print@u@default\@getprint{\@title}\end{@norefs}}
 \fi
 \@print@endline{</title>}%
-\ifmathml\@print@endline{<style type="text/css">
-  math.centered { text-align: center}
+\ifmathml\@print@endline{<style>
+  math.centered {text-align: center}
 </style>}\fi
 \@print@endline{</head>}%
 \@print{<body }\@notags{\@bodyargs}\@print@endline{>}%

--- a/html/hevea.hva
+++ b/html/hevea.hva
@@ -12,14 +12,12 @@
 % Linking to external style sheets
 \newtokens{\css@link}%
 \newcommand{\addcssfile}[1]{\addtokens{\css@link}{#1}}%
-\newcommand{\loadcssfile}[1]{\addcssfile{\@print{<}\@getprint{link rel="stylesheet" type=\char34 text/css\char34\@print{ }href=\char34#1\char34\char62\@print{
-}}}}%
+\newcommand{\loadcssfile}[1]{\addcssfile{\@print{<}\@getprint{link rel="stylesheet" type=\char34 text/css\char34\@print{ }href=\char34#1\char34\char62\@print@endline{}}}}%
 %%%%%%
 % Styles definition in the <HEAD> element
 \newtokens{\hevea@css}%
 \newcommand{\addstyle}[1]{\addtokens{\hevea@css}{#1}}%
-\newcommand{\newstyle}[2]{\addstyle{\@getprint{#1\char123#2\char125\@print{
-}}}}%
+\newcommand{\newstyle}[2]{\addstyle{\@getprint{#1\char123#2\char125\@print@endline{}}}}%
 \newif\ifexternalcss\externalcssfalse
 %
 %%Style attributes are normaly set through an indirection.
@@ -82,11 +80,9 @@
 \newcommand{\htmlfoot}[1]{\sbox{\@htmlfoot}{#1}}
 \newcommand{\htmlprefix}[1]{\sbox{\@htmlprefix}{#1}}
 \AtEndDocument
-{\@close@par{\@nostyle\@print{<!--HTMLFOOT-->
-}}%
+{\@close@par{\@nostyle\@print@endline{<!--HTMLFOOT-->}}%
 \usebox{\@htmlfoot}%
-{\@nostyle\@print{<!--ENDHTML-->
-}}}
+{\@nostyle\@print@endline{<!--ENDHTML-->}}}
 %%%%% Footnotes, html dependant part
 \newcommand{\@noteref}[4]{\@locnameref{#2#3}{#1#3}{#4}}
 \newcommand{\@notepointer}[3]{\@locref{#1#2}{#3}}
@@ -109,13 +105,13 @@
 \newstyle{.footnoterule}{margin:1em auto 1em 0px;width:50\%;}
 \newcommand{\footnoterule}{\@hr[\envclass@attr{footnoterule}]{}{}}
 \newenvironment{thefootnotes}[2][]
-  {\@out@par{{\@nostyle\@print{<!--BEGIN }\@getprint{#1}\@print{NOTES }\@getprint{\@footnotelevel}\@print{-->
-}}}\footnoterule%
-  \setlistclass{thefootnotes}%
-  \begin{list}{}{\renewcommand{\makelabel}[1]{##1}}}
-  {\end{list}\@out@par{{\@nostyle\@print{
-<!--END NOTES-->
-}}}}
+  {\@out@par{{\@nostyle\@print{<!--BEGIN }%
+   \@getprint{#1}\@print{NOTES }\@getprint{\@footnotelevel}%
+   \@print@endline{-->}}}\footnoterule%
+   \setlistclass{thefootnotes}%
+   \begin{list}{}{\renewcommand{\makelabel}[1]{##1}}}
+  {\end{list}\@out@par{{\@nostyle\@print@endline{
+<!--END NOTES-->}}}}
 %%% Captions html dependent part
 \newstyle{.caption}
 {padding-left:2ex; padding-right:2ex; margin-left:auto; margin-right:auto}
@@ -130,8 +126,7 @@
 \newcommand{\cutdef*}[2][]
 {\@out@par{{\@nostyle\@print{<!--CUT DEF }#2\@print{ }#1\@print{ -->}}}}
 \newcommand{\cutend*}
-{\@out@par{{\@nostyle\@print{<!--CUT END -->
-}}}}
+{\@out@par{{\@nostyle\@print@endline{<!--CUT END -->}}}}
 %%% New cutdef/cutend, with footnote managment
 \hva@newstack{@foot}
 \newcommand{\cutdef}[2][]{%
@@ -139,8 +134,7 @@
 \@out@par{{\@nostyle\@print{<!--CUT DEF }#2\@print{ }#1\@print{ -->}}}}
 \newcommand{\cutend}{%
 \footnoteflush{\@footnotelevel}%
-\@out@par{{\@nostyle\@print{<!--CUT END -->
-}}}%
+\@out@par{{\@nostyle\@print@endline{<!--CUT END -->}}}%
 \@endfootnotesub\@pop@foot{\@footnotelevel}}
 %%%Close/Re-open toplevel pars
 \newcommand{\@secbegin}{\@close@par}
@@ -151,8 +145,7 @@
 \@footnoteflush{#1}%
 {\@out@par{{\@nostyle\@print{<!--TOC }\@getprint{#1}\@print{ }}%
 {\@nostyle{}\@print{id="}\@getprint{\@sec@id@attr}\@print{" }}%
-\begin{@norefs}#2\end{@norefs}{\@nostyle\@print{-->
-}}}}}
+\begin{@norefs}#2\end{@norefs}{\@nostyle\@print@endline{-->}}}}}
 \newcommand{\@hacha@arg}[2]
 {{\@nostyle\@print{<arg }\@getprint{#1}\@print{>}{#2}\@print{</arg>}}}
 \newenvironment{@cutflow}[2]
@@ -166,8 +159,7 @@
 \newenvironment{cutflow}[1]{\begin{@cutflow}{YES}{#1}}{\end{@cutflow}}
 \newenvironment{cutflow*}[1]{\begin{@cutflow}{NO}{#1}}{\end{@cutflow}}
 \newcommand{\cutname}[1]
-{\@out@par{{\@nostyle\@print{<!--NAME }\@getprint{#1}\@print{-->
-}}}}
+{\@out@par{{\@nostyle\@print{<!--NAME }\@getprint{#1}\@print@endline{-->}}}}
 \newcommand{\@link@arg}[2]
   {\ifthenelse{\equal{#2}{}}{}
   {\@hacha@arg{#1}{#2}}}
@@ -217,14 +209,14 @@
   {\@forcecommand{#1}{\begin{toimage}#1\end{toimage}#2}}
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%   \maketitle (is no longer redefined by fancysection)		%
-%   Thus defining different styles explicitly will have to 	%
-%     be done using the respective classes :			%
+%   \maketitle (is no longer redefined by fancysection)         %
+%   Thus defining different styles explicitly will have to      %
+%     be done using the respective classes :                    %
 %     .title     : table containing the title and supplements   %
-%     .titlemain : h1 containing title name		        %
+%     .titlemain : h1 containing title name                     %
 %     .titlerest : h3 containing other fields (author,date,etc.)%
 %   'checkbox' now takes three instead of two arguments,        %
-%     one for the class.					%
+%     one for the class.                                        %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
 \newcommand{\title@tohaux}[1]
@@ -282,45 +274,36 @@
 \@getprint{\@charset}%
 \@print{">
 <meta name="generator" content="hevea }%
-\@getprint{\usebox{\@heveaversion}}\@print{">
-}%
+\@getprint{\usebox{\@heveaversion}}\@print@endline{">}%
 \ife\hevea@css\else
 \ifexternalcss\loadcssfile{\hva@dump@css}\else
 \@print{<style type="text/css">}
-\hevea@css\@print{</style>
-}\fi\fi
+\hevea@css\@print@endline{</style>}\fi\fi
 \ife\css@link\else\css@link\fi
 \undef\hevea@css\undef\newstyle}
 \newenvironment{document}{%
 \@end{document}%
 \@atbegindocument%
 \@restartoutput\unskip%
-\@print{<!DOCTYPE html>
-}\@print{<html }\@getprint{\@htmlargs}\@print{>
+\@print@endline{<!DOCTYPE html>}%
+\@print{<html }\@getprint{\@htmlargs}\@print{>
 <head>}
 \@meta%
 \@print{<title>}%
 \ifu\@title\jobname\else
 \@notags{\begin{@norefs}\let\@print@u\@print@u@default\@getprint{\@title}\end{@norefs}}
 \fi
-\@print{</title>
-}%
-\ifmathml\@print{<style type="text/css">
+\@print@endline{</title>}%
+\ifmathml\@print@endline{<style type="text/css">
   math.centered { text-align: center}
-</style>
-}\fi
-\@print{</head>
-}%
-\@print{<body }\@notags{\@bodyargs}\@print{>
-}%
-\@print{<!--HEVEA command line is: }\usebox{\@heveacomline}\@print{-->
-}%
+</style>}\fi
+\@print@endline{</head>}%
+\@print{<body }\@notags{\@bodyargs}\@print@endline{>}%
+\@print{<!--HEVEA command line is: }\usebox{\@heveacomline}\@print@endline{-->}%
 {\@nostyle\@print{<!--CUT STYLE }\hacha@style\@print{-->}}%
-\ife\@htmlhead\else{\@nostyle\@print{<!--HTMLHEAD-->
-}}%
+\ife\@htmlhead\else{\@nostyle\@print@endline{<!--HTMLHEAD-->}}%
 \usebox{\@htmlhead}%
-{\@nostyle\@print{<!--ENDHTML-->
-}}\fi%
+{\@nostyle\@print@endline{<!--ENDHTML-->}}\fi%
 \ife\@htmlprefix\else\@printnostyle{<!--PREFIX }%
 \@hacha@arg{}{\usebox{\@htmlprefix}}%
 \@printnostyle{-->
@@ -336,9 +319,9 @@
 \@atenddocument%
 \@final@footer%
 \@clearstyle%
-\@print{</body>
-</html>
-}\@raise@enddocument}
+\@print@endline{</body>
+</html>}%
+\@raise@enddocument}
 \newstyle{.center}{text-align:center;margin-left:auto;margin-right:auto;}%
 \newstyle{.flushleft}{text-align:left;margin-left:0ex;margin-right:auto;}%
 \newstyle{.flushright}{text-align:right;margin-left:auto;margin-right:0ex;}%
@@ -578,16 +561,16 @@
 \newcommand{\@table@attributes@border}{style="border-spacing:0" class="cellpadding1"}
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%   Redefining \textoverline of latexcommon.hva			%
-%   Here we can use HTML primitives				%
+%   Redefining \textoverline of latexcommon.hva                 %
+%   Here we can use HTML primitives                             %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
 \newcommand{\overlinedbox}[1]%
-     {{\@styleattr{span}{style="text-decoration:overline"}#1}}% 
+     {{\@styleattr{span}{style="text-decoration:overline"}#1}}%
 \renewcommand{\textoverline}[1]{\overlinedbox{#1}}%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%   Redefining \fbox of latexcommon.hva	         		%
-%   Here we can use HTML primitives				%
+%   Redefining \fbox of latexcommon.hva                         %
+%   Here we can use HTML primitives                             %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \newstyle{.lrbox}{box-sizing:border-box;display:inline-block;overflow:visible;white-space:nowrap;}
 \newstyle{.center-lrbox}{display:inline-block;margin-left:50\%;transform:translateX(-50\%);}

--- a/html/symb-mathml.hva
+++ b/html/symb-mathml.hva
@@ -47,20 +47,17 @@
 
 % Roots
 \newcommand{\sqrt}[2][!*!]{\ifthenelse{\equal{#1}{!*!}}%
-{\@print{<msqrt>
-}%
+{\@print@endline{<msqrt>}%
 #2\@print{
 </msqrt>}%
-}{\@print{<mroot>
-}\@open{display}{}%
+}{\@print@endline{<mroot>}\@open{display}{}%
 #2
 \@close{display}{}%
 \@open{display}{}%
 #1%
 \@close{display}{}%
-\@print{
-</mroot>
-}}}
+\@print@endline{
+</mroot>}}}
 
 % Ellipsis
 \renewcommand{\ldots}{\ifmath\@mop{TripleDot}\else{...}\fi}

--- a/labeltype.hva
+++ b/labeltype.hva
@@ -9,8 +9,7 @@
 \let\@rt@old@label\label
 \renewcommand{\label}[2][]
 {\@rt@old@label[#1]{#2}%
-\@auxdowrite{\@print{\@deflabeltype}\{#2\}\{\currentlabeltype\}\@print{
-}}}
+\@auxdowrite{\@print{\@deflabeltype}\{#2\}\{\currentlabeltype\}\@print@endline{}}}
 %%Hum also redefines \enumerate...
 \let\@rt@oldenumerate\enumerate
 \renewcommand{\enumerate}{\def\currentlabeltype{item}\@rt@oldenumerate}

--- a/latexcommon.hva
+++ b/latexcommon.hva
@@ -85,7 +85,7 @@
 \renewcommand{\@hevea@amper}
   {\ifthenelse{\value{@eqna@col}<2}
     {\stepcounter{@eqna@col}\@PAM}
-    {\hva@warn{Extra column in eqnarray}}}     
+    {\hva@warn{Extra column in eqnarray}}}
 \renewcommand{\\}[1][]{\@eqna@complete\@PAM\@number\setcounter{@eqna@col}{0}\@yesnumber\stepcounter{equation}\@PBS}
 \@array{rclr}}
 {\\{}\addtocounter{equation}{-1}\end@array\]\@close{div}}
@@ -227,11 +227,11 @@
   \setcounter{\@itemcount}{0}}
   {\@close{OL}\addtocounter{enumcount}{-1}}
 %
-%% Modified to support styles e.g. 
+%% Modified to support styles e.g.
 %%                <DL class=list>,
 %%                <DT class=dt-list>
 %% ONLY CHANGES : 1) class=list added to \@open{DL} argument
-%%                2) \@dt replaced by \@list@dtdd 
+%%                2) \@dt replaced by \@list@dtdd
 %% Remove these to get original behaviour
 %
 \newcommand{\setlistclass}[1]
@@ -565,8 +565,7 @@
 %}}}
 \newcommand{\@doaddtoc}[3]
 {%\stepcounter{tocanchor}%
-\@auxdowrite{\@print{\@@addtocsec{htoc}}\{\@getprintnostyle{\@sec@id@attr}\}\{#1\}\{\@checkdepth{#1}{\@print{\@print}\{#2\}\@print{\quad{}}}\begin{@norefs}\@subst@expn{#3}\end{@norefs}\}\@print{
-}}}
+\@auxdowrite{\@print{\@@addtocsec{htoc}}\{\@getprintnostyle{\@sec@id@attr}\}\{#1\}\{\@checkdepth{#1}{\@print{\@print}\{#2\}\@print{\quad{}}}\begin{@norefs}\@subst@expn{#3}\end{@norefs}\}\@print@endline{}}}
 %%section identifiers
 \newcounter{@sec}
 \newcommand{\@fmt@sec}{sec\arabic{@sec}}
@@ -688,8 +687,7 @@
 \@iffileexists{\jobname.#1}{\input{\jobname.#1}}{}}
 \newcommand{\tableofcontents}{\@readtoc{htoc}{\contentsname}}
 \newcommand{\addcontentsline}[3]
-{\@auxdowrite{{\@nostyle\@print{\@addcontentsline}{\{h#1\}\{\csname @#2@level\endcsname\}}\{\@subst{#3}\}\@print{
-}}}}
+{\@auxdowrite{{\@nostyle\@print{\@addcontentsline}{\{h#1\}\{\csname @#2@level\endcsname\}}\{\@subst{#3}\}\@print@endline{}}}}
 %%%%%%%%% Minipage
 %Manage footnotes in minipage, as latex does
 % 1. Use counter mpfootnote

--- a/latexscan.mll
+++ b/latexscan.mll
@@ -2382,6 +2382,13 @@ def_code "\\@print"
     Dest.put arg)
 ;;
 
+def_code "\\@print@endline"
+  (fun lexbuf ->
+    let {arg=arg} = save_arg lexbuf in
+    Dest.put arg;
+    Dest.put_char '\n')
+;;
+
 let put_unicode_default uc =
   try
     let txt = OutUnicode.get_default uc in

--- a/lexstyle.mll
+++ b/lexstyle.mll
@@ -70,8 +70,7 @@ and skip_comment = parse
 | "" { error "comment" lexbuf }
 
 and dump m out = parse
-| "<style" blank+ "type" blank* "=" blank* '"' "text/css" '"' blank* '>' '\n'?
-  as lxm
+| "<style>" '\n'? as lxm
    { fprintf out "%s" lxm ;
      Emisc.StringMap.iter
        (fun st cl -> Emisc.dump_class out cl st)

--- a/spaces.hva
+++ b/spaces.hva
@@ -6,8 +6,7 @@
 \def\!{}
 \def\;{\@print@u{8196}}% TeX: thick space: 5/18 quad; Unicode: emsp13, 6/18 quad!
 \def\
-{\@print{
-}}
+{\@print@endline{}}
 \def\frenchspacing{}
 \def\nonfrenchspacing{}
 \def\/{}


### PR DESCRIPTION
The **vnu** checker as of version 20.6.30 always turns up the following
problems with Hevea-generated HTML files (edited for clarity):

```
Line 4: error: Internal encoding declaration "us-ascii" disagrees
               with the actual encoding of the document ("utf-8").
Line 4: error: Bad value "text/html; charset=US-ASCII" for
               attribute "content" on element "meta": "charset="
               must be followed by "utf-8".
Line 6: info warning: The "type" attribute for the "style"
                      element is not needed and should be omitted.
```

This P/R addresses all three diagnostics.

In the course of fixing the problems it turned out that a new
(internal) macro `\@print@endline` would be beneficial for
the clarity and simplicity of expression.  So the P/R has been
split into three patches:

1. Introduce and document `\@print@endline`.
1. Use the new macro in every position where `\@print`
needs to add a final newline character.
1. Fix macro `\@meta` which generates the relevant part
of the `head`-element's contents.  Update intertwined lexers
accordingly.

With this P/R Hevea generates **vnu**-clean headers.
