### PR TITLE
SVG-based macro \rule

### DIFF
--- a/doc/text.tex
+++ b/doc/text.tex
@@ -5535,9 +5535,6 @@ It is retrieved (and outputted) by the command
 The \verb+\savebox+ command reduces to \verb+\sbox+, ignoring its
 optional arguments.
 
-The \verb+\rule+ commands translate to a \html{} horizontal rule
-(\verb+<HR>+)  regardless of its arguments.
-
 \smallskip
 
 No other box-related commands are implemented.

--- a/html/hevea.hva
+++ b/html/hevea.hva
@@ -382,7 +382,6 @@
 \newcommand{\centering}{\@insert{div}{\envclass@attr{center}}}
 \newcommand{\raggedleft}{\@insert{div}{\envclass@attr{flushright}}}
 \newcommand{\raggedright}{\@insert{div}{\envclass@attr{flushleft}}}
-\newcommand{\rule}[3][]{\@printHR{}{}}%
 %%special boxes
 \newstyle{.parbox}{
   box-sizing: border-box;
@@ -415,6 +414,14 @@
   \@open{span@inline@block}{class="parbox" style="vertical-align:\@align;width:\css@length{#2}"}%
   #3%
   \@close{span@inline@block}%
+}
+\newstyle{.rule-rect}{fill: black;}
+\newcommand{\rule}[3][]{%
+  \ife#1\relax\else\@open{div}{style="display:inline-block;transform:translateY(calc(0pt - ( \css@length{#1} )))"}\fi
+  \@open{svg}{height="\css@length{#3}" width="\css@length{#2}"}%
+  \@print{<rect class="rule-rect" }height="100\%" width="100\%\@print{"></rect>}%
+  \@close{svg}%
+  \ife#1\relax\else\@close{div}\fi
 }
 \RenewcommandHtml{\@raisebox}[4]{%
   \def\@height{max-content}%

--- a/latexcommon.hva
+++ b/latexcommon.hva
@@ -734,6 +734,6 @@
 {This document was translated from \LaTeX{} by
 \footahref{\heveaurl/index.html}{\hevea}.}
 \newcommand{\@footer}
-{\rule{}{}\begin{quote}\em\footertext\end{quote}}
+{\@printHR{}{}\begin{quote}\em\footertext\end{quote}}
 %%%%% Compat
 %\let\@hva@newstack\hva@newstack

--- a/package.ml
+++ b/package.ml
@@ -378,7 +378,10 @@ def_code "\\css@length"
       match Get.get_length arg with
       | Length.Pixel n -> Printf.sprintf "%ipx" n
       | Length.Char n ->  Printf.sprintf "%iem" n
-      | _ -> warning "\\css@length cannot interpret this length" ; "0px" in
+      | Length.Percent n -> Printf.sprintf "%i%%" n
+      | _not_a_length ->
+         warning ("\\css@length cannot interpret \"" ^ arg ^ "\" as length; substituting 0px");
+         "0px" in
     Dest.put len)
 ;;
 


### PR DESCRIPTION
Implement macro `\rule` with SVG.  Its properties nicely match
the LaTeX original as it is rendered inline and zero-width width
or height lead to an invisible "strut".

Try it for example with

```latex
\documentclass{article}

\usepackage{hevea}

\newenvironment{markerbar}{\begingroup$|$}{$|$\endgroup}

\begin{document}
\section{Rules}

\texttt{\textbackslash rule}; size is indicated as width/height and
optionally followed by a signed offset.

\begin{itemize}
\item 10em/0.0625em: \rule{10em}{0.0625em}
\item 1em/1em: \rule{1em}{1em}
\item 0.0625em/3em: \rule{0.0625em}{3em}
\item 50\% linewidth/2pt: \rule{0.5\linewidth}{2pt}
\end{itemize}

\noindent Struts (zero width or zero height) -- extents indicated with marker bars

\begin{itemize}
  \item 10em/0pt: \begin{markerbar}\rule{10em}{0pt}\end{markerbar}
  \item 0pt/3em: \begin{markerbar}\rule{0pt}{3em}\end{markerbar}
\end{itemize}

\noindent Raised or lowered rules.

\begin{itemize}
\item 10em/0.0625em$+12$pt: \rule[12pt]{10em}{0.0625em}
\item 1em/1em$+6$pt: \rule[6pt]{1em}{1em}
\item 0.0625em/3em$-12$pt: \rule[-12pt]{0.0625em}{3em}
\end{itemize}

\ifhevea
  \noindent Comparison with \texttt{\textbackslash\char64 hr} (HeVeA only).

  \begin{itemize}
  \item 10em/0.0625em: \@hr{10em}{0.0625em}
  \item 1em/1em: \@hr{1em}{1em}
  \item 0.0625em/3em: \@hr{0.0625em}{3em}
  \item 50\% linewidth/2pt: \@hr{0.5\linewidth}{2pt}
  \item $2\times$ 5em/5pt: \@hr{5em}{5pt}. \@hr{5em}{5pt}.
  \end{itemize}
\fi
\end{document}
```

The implementation is *not* backward compatible.  It breaks the
previously valid call `\rule{}{}` (which is invalid LaTeX code, though).
Replacing those calls with a suitably tailored `\@hr` restores the old
behavior _and_ is fully backward compatible.

If we ever should merge this P/R the OCaml compiler guys may want
to apply

```diff
--- a/manual/manual/allfiles.etex
+++ b/manual/manual/allfiles.etex
@@ -24,7 +24,7 @@
 
 \begin{htmlonly}
 \begin{quote}
-\rule{}{}
+\@hr{\linewidth}{0.75pt}
 This manual is also available in
 \ahref{https://ocaml.org/releases/\ocamlversion/ocaml-\ocamlversion-refman.pdf}{PDF},
 \ahref{https://ocaml.org/releases/\ocamlversion/ocaml-\ocamlversion-refman.txt}{plain text},
@@ -32,7 +32,7 @@ as a
 \ahref{https://ocaml.org/releases/\ocamlversion/ocaml-\ocamlversion-refman-html.tar.gz}{bundle of HTML files},
 and as a
 \ahref{https://ocaml.org/releases/\ocamlversion/ocaml-\ocamlversion-refman.info.tar.gz}{bundle of Emacs Info files}.
-\rule{}{}
+\@hr{\linewidth}{0.75pt}
 \end{quote}
 \end{htmlonly}
 ```
