### PR TITLE
Synchronize GNU Info and Plain Text output with HTML output.

### DIFF
--- a/html/hevea.hva
+++ b/html/hevea.hva
@@ -494,11 +494,20 @@
 \def\textsl#1{\mbox{\slshape#1}}
 \def\textsc#1{\mbox{\scshape#1}}
 \newcommand{\emph}[1]{\mbox{\em#1}}
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%  New implementation of \sc & \textsc using "small-caps" style. %
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%
-%
+%%%%%%%%%%%% Emulate hyphenation
+\newcommand{\soft@hyphen}{\@print{&#173;}}
+\newcommand{\zero@width@space}{\@print{&#8203;}}
+\newcommand{\zero@width@non@joiner}{\@print{&#8204;}}
+\newcommand{\breakable@hyphen}{\@print{&#8208;}}
+\newcommand{\zero@width@joiner}{\@print{&#8288;}}
+\newcommand{\tag@wordbreak}{\@print{<wbr>}}
+\newcommand{\word@break@opportunity}{\tag@wordbreak}% use e.g. `\zero@width@space' or `\tag@wordbreak'
+\newcommand{\-}{\soft@hyphen}
+\newcommand{\discretionary}[3]{%
+  \ifthenelse{\equal{#1#2#3}{}}{\word@break@opportunity}{%
+    \ifthenelse{\equal{#1}{-}\and\equal{#2#3}{}}{\soft@hyphen}{%
+      \ifthenelse{\equal{#1}{-}\and\equal{#2}{}\and\equal{#3}{-}}{\breakable@hyphen}{%
+        #3}}}}
 %%%%%%%%%%%%%%% Multicolumns index formating
 \newcommand{\setindexpos}[2]
 {\providesavebox{\csname indexpos#1\endcsname}%

--- a/hyphenat.hva
+++ b/hyphenat.hva
@@ -15,5 +15,5 @@
 \newcommand{\fshyp}{\ifmmode/\else\breakable@slash\fi}
 \newcommand{\dothyp}{\ifmmode.\else\breakable@dot\fi}
 \newcommand{\colonhyp}{\ifmmode:\else\breakable@colon\fi}
-\newcommand{\BreakableHyphen}{\@print{&#8208;}}
+\newcommand{\BreakableHyphen}{\breakable@hyphen}
 \newcommand{\hyp}{\ifmmode-\else\BreakableHyphen\fi}

--- a/iso-symb.hva
+++ b/iso-symb.hva
@@ -19,8 +19,8 @@
 \let\textbraceright\}
 \DeclareSymbol[*]{\textbullet}{X2022}
 \DeclareSymbol[(c)]{\textcopyright}{XA9}
-\DeclareSymbolHtml{\textdagger}{8224}
-\DeclareSymbolHtml{\textdaggerdbl}{8225}
+\DeclareSymbol[\@print{+}]{\textdagger}{8224}
+\DeclareSymbol[\@print{++}]{\textdaggerdbl}{8225}
 \let\textdollar\$
 \DeclareSymbol[...]{\textellipsis}{X2026}
 \DeclareSymbolHtml[\@print{--}]{\textemdash}{X2014}

--- a/latexcommon.hva
+++ b/latexcommon.hva
@@ -274,19 +274,7 @@
 \newenvironment{sloppypar}{}{}
 \newcommand{\goodbreak}{}
 %%%%%%%%%%%% Emulate hyphenation
-\newcommand{\soft@hyphen}{\@print{&#173;}}
-\newcommand{\zero@width@space}{\@print{&#8203;}}
-\newcommand{\zero@width@non@joiner}{\@print{&#8204;}}
-\newcommand{\breakable@hyphen}{\@print{&#8208;}}
-\newcommand{\tag@wordbreak}{\@print{<wbr>}}
-\newcommand{\word@break@opportunity}{\tag@wordbreak}% use e.g. `\zero@width@space' or `\tag@wordbreak'
-\newcommand{\-}{\soft@hyphen}
 \newcommand{\hyphenation}[1]{}
-\newcommand{\discretionary}[3]{%
-  \ifthenelse{\equal{#1#2#3}{}}{\word@break@opportunity}{%
-    \ifthenelse{\equal{#1}{-}\and\equal{#2#3}{}}{\soft@hyphen}{%
-      \ifthenelse{\equal{#1}{-}\and\equal{#2}{}\and\equal{#3}{-}}{\breakable@hyphen}{%
-        #3}}}}
 %% Page Breaking
 \newcommand{\pagebreak}[1][]{}
 \newcommand{\nopagebreak}[1][]{}
@@ -377,8 +365,16 @@
 \newcommand{\parbox}[3][]{\hva@warn{parbox}#3}
 \newcommand{\textfbox}[1]{\hva@warn{\fbox in text}\mbox{#1}}
 \def\fbox#1{%
-\ifdisplay\begin{tabular}{|c|}\hline#1\end{array}\else
-\textfbox{#1}\fi}
+  \ifdisplay
+    \begin{array}{|c|}%
+      \hline
+      #1%
+      \hline
+    \end{array}%
+  \else
+    \textfbox{#1}%
+  \fi
+}
 \newcommand{\hbox}[1]{\hva@warn{\hbox}\mbox{#1}}
 \newcommand{\displaystyle}{\ifdisplay\else\hva@warn{\displaystyle ignored}\fi}
 %%% Paragraphs

--- a/latexscan.mll
+++ b/latexscan.mll
@@ -3388,6 +3388,26 @@ def_code "\\@vdotsfill"
         lexbuf)
 ;;
 
+let single_space = "\\@print{ }" in
+  OutUnicode.def_default OutUnicode.emsp single_space;
+  OutUnicode.def_default OutUnicode.ensp single_space;
+  OutUnicode.def_default OutUnicode.emsp13 single_space;
+  OutUnicode.def_default OutUnicode.emsp14 single_space;
+  OutUnicode.def_default OutUnicode.six_per_em_space single_space;
+  OutUnicode.def_default OutUnicode.hairsp single_space;
+  OutUnicode.def_default OutUnicode.six_per_em_nbsp single_space;
+  OutUnicode.def_default OutUnicode.medium_space single_space;
+;;
+
+OutUnicode.def_default OutUnicode.visible_space "\\@print{_}";
+;;
+
+OutUnicode.def_default OutUnicode.zero_width_space "";
+OutUnicode.def_default OutUnicode.zero_width_joiner "";
+OutUnicode.def_default OutUnicode.word_joiner "";
+;;
+
+
 (* Explicit groups *)
 def_code "\\begingroup"
   (fun lexbuf  ->

--- a/outUnicode.ml
+++ b/outUnicode.ml
@@ -70,11 +70,11 @@ let translate_ascii_out i put =
 and translate_ascii_in c _ =
   let i = Char.code c in
   if i < 128 then i
-  else  cannot ()
+  else cannot ()
 
 let translate_latin1_out i put =
   if i < 256 then put (Char.unsafe_chr i)
-  else  cannot ()
+  else cannot ()
 
 and translate_latin1_in c _ = Char.code c
 
@@ -846,6 +846,9 @@ and six_per_em_space = 0x2006
 and hairsp = 0x200A
 and zero_width_space = 0x200B
 and zero_width_joiner = 0x200D (* zwj *)
+and six_per_em_nbsp = 0x202F
+and medium_space = 0x205F
+and word_joiner = 0x2060
 
 (* Accents and the like *)
 

--- a/outUnicode.mli
+++ b/outUnicode.mli
@@ -76,6 +76,9 @@ val six_per_em_space : unichar
 val hairsp : unichar
 val zero_width_space : unichar
 val zero_width_joiner : unichar
+val six_per_em_nbsp : unichar
+val medium_space : unichar
+val word_joiner : unichar
 val acute_alone : unichar
 val grave_alone : unichar
 val circum_alone : unichar

--- a/spaces.hva
+++ b/spaces.hva
@@ -17,7 +17,7 @@
 \def\smallskip{\vspace*{1em}}
 \def\medskip{\vspace*{1em}}
 \def\bigskip{\vspace*{2em}}
-\def\enspace{\@print@u{8288}\@print@u{8194}\@print@u{8288}}% TeX: 1/2 quad; Unicode: word-joiner + ensp + word-joiner  =>  non-breaking en-space.
+\def\enspace{\zero@width@joiner\@print@u{8194}\zero@width@joiner}% TeX: 1/2 quad; Unicode: word-joiner + ensp + word-joiner  =>  non-breaking en-space.
 \def\enskip{\@print@u{8194}}% TeX: 1/2 quad; Unicode: ensp, 1/2 quad.
 \def\quad{\@print@u{8195}}% TeX: 1 quad; Unicode: emsp, 1 quad.
 \def\qquad{\@print@u{8195}\@print@u{8195}}% TeX: 2 quad; Unicode: emsp + emsp, 2 quad.

--- a/text/color.hva
+++ b/text/color.hva
@@ -4,3 +4,5 @@
 \newcommand{\color}[2][!*!]{}
 \newcommand{\textcolor}[3][!*!]{{#3}}
 \newenvironment{bgcolor}[2][]{}{}
+\newcommand{\colorbox}[3][!*!]{{#3}}
+\newcommand{\fcolorbox}[4][!*!]{{#4}}

--- a/text/hevea.hva
+++ b/text/hevea.hva
@@ -187,6 +187,19 @@
 \def\textsl#1{\mbox{\slshape#1}}
 \def\textsc#1{\mbox{\scshape#1}}
 \newcommand{\emph}[1]{\mbox{\em#1}}
+%%%%%%%%%%%% Emulate hyphenation
+\newcommand{\soft@hyphen}{}
+\newcommand{\zero@width@space}{}
+\newcommand{\zero@width@non@joiner}{}
+\newcommand{\breakable@hyphen}{-}
+\newcommand{\zero@width@joiner}{}
+\newcommand{\word@break@opportunity}{}
+\newcommand{\-}{}
+\newcommand{\discretionary}[3]{%
+  \ifthenelse{\equal{#1#2#3}{}}{}{%
+    \ifthenelse{\equal{#1}{-}\and\equal{#2#3}{}}{}{%
+      \ifthenelse{\equal{#1}{-}\and\equal{#2}{}\and\equal{#3}{-}}{-}{%
+        #3}}}}
 %%%%%%%%% Index formating
 \newenvironment{indexenv}{\begin{itemize}}{\end{itemize}}
 \newcommand{\indexitem}{\item}
@@ -194,6 +207,18 @@
 %%%%%%%%concrete minipage
 \setenvclass{minipage}{minipage}
 \newenvironment{@minipage}{}{}
+%%%%%%%%margin par
+\newif\ifmarginright\marginrighttrue
+\newcommand{\normalmarginpar}{\marginrighttrue}
+\newcommand{\reversemarginpar}{\marginrightfalse}
+\newcommand{\marginpar}[2][]{%
+  \def\hva@mtemp{#1}%
+  \ifmarginright
+    \@print{ >>}#2\@print{>> }%
+  \else
+    \@print{ <<}\ifx\hva@mtemp\@empty #2\else #1\fi\@print{<< }%
+  \fi
+}
 %%%%%% format theorems
 \let\th@font\em
 \newcommand{\set@th}[1]
@@ -208,5 +233,7 @@
 %%%%%%%%%% No attributes for arrays and tabular
 \newcommand{\@table@attributes}{}
 \newcommand{\@table@attributes@border}{}
+%%%%%%%%%% No CSS styles of course
+\newenvironment{divstyle}[1]{\begingroup}{\endgroup}
 %% Over
 \def\csname hevea@loaded\endcsname{}

--- a/verb.mll
+++ b/verb.mll
@@ -995,7 +995,7 @@ let _ = ()
 ;;
 
 let put_char_star c next = match c with
-  | ' ' | '\t' -> Dest.put_unicode OutUnicode.visible_space;
+  | ' ' | '\t' -> Dest.put (Scan.get_prim "\\textvisiblespace")
   | c -> Scan.translate_put_unicode c next
 
 and put_char c next = match c with


### PR DESCRIPTION
Some of my previous extensions to the HTML generation neglected
the GNU Info and Plain Text output.  #34 is particularly gross in that
it introduces an uncaught exception for the perfectly valid LaTeX
code ``\verb*+ +``.  This P/R plugs many other leaks that sneaked
in e.g. with #23 and #35.

I rose to the occasion and implemented e.g. environment ``divstyle``
and macros ``\colorbox``, ``\fcolorbox`` as "dumb" expansions that
simply replicate their _TEXT_ contents/arguments.  This cleans up
text output nicely.

If somebody finds missing environments or macros for GNU Info or
Plain Text output please touch base with me so that we can get this
stuff out of the way.
