### PR TITLE
Fix environment name s/FlushLeftRight/FlushRight/.

### DIFF
--- a/ragged2e.hva
+++ b/ragged2e.hva
@@ -1,10 +1,13 @@
-\let\RaggedRight\raggedright
-\let\RaggedLeft\raggedleft
 \let\Centering\centering
+\let\endCentering\relax
+\let\RaggedLeft\raggedleft
+\let\endRaggedLeft\relax
+\let\RaggedRight\raggedright
+\let\endRaggedRight\relax
 \newstyle{.justify}{text-align:justify;margin-left:auto;margin-right:auto;}
 \newcommand{\justifying}{\@insert{div}{\envclass@attr{justify}}}
 \newenvironment{Center}{\begin{center}}{\end{center}}
 \newenvironment{FlushLeft}{\begin{flushleft}}{\end{flushleft}}
-\newenvironment{FlushLeftRight}{\begin{flushright}}{\end{flushright}}
+\newenvironment{FlushRight}{\begin{flushright}}{\end{flushright}}
 \setenvclass{justify}{justify}
 \newenvironment{justify}{\@open{div}{\envclass@attr{justify}}}{\@close{div}}


### PR DESCRIPTION
Also add some missing end-of-environment macros, which caused warnings.

@maranget: In this context I'm not satisfied with ``Html.insert_block``.

```ocaml
and insert_block s attr =
  if find_prev_par () then
    warning "Ignoring \\centering or \\ragged..."
  else
    insert_block (find_block s) attr
```

The "warning" is potentially misleading; it is not only triggred by the
macros it mentions.
