### PR TITLE
Flexible float decoration

### DIFF
--- a/doc/text.tex
+++ b/doc/text.tex
@@ -4322,7 +4322,7 @@ Paragraph are rendered by \verb+p+ elements.
 In some occasions, this technique may produce spurious paragraphs
 (see~\ref{spurious:par}).
 
-\subsection{Footnotes}
+\subsection{Footnotes\label{sec:footnotes}}
 The commands \verb+\footnote+,
 \verb+\footnotetext+ and \verb+\footnotemark+ (with or without
 optional arguments) are supported.
@@ -5051,19 +5051,44 @@ with the boolean registers of the \texttt{ifthen} package, as it is
 the case in \LaTeX.
 
 
-\section{Figures and Other Floating Bodies}
+\section{Figures, Tables, and Other Floating Bodies}
 
-Figures and tables are put where they appear in source, regardless of
-their placement arguments.
-They are outputted  inside a \verb+BLOCKQUOTE+ element and they are
-separated from enclosing text by two
-horizontal rules.
+\subsection{Figures And Tables}
 
-Captions and cross referencing are handled.
-However captions are not moved at end of figures: instead, they appear
-where the \verb+\caption+ commands occur in source code.
-The \verb+\suppressfloats+ command does nothing and the
-figure related counters (such as \verb+topnumber+) exist but are useless.
+Figures and tables are put where they appear in the source
+(location~``\verb+h+''), regardless of their placement arguments.
+\hevea{} wraps them in \verb+BLOCKQUOTE+~elements that are associated
+with CSS~classes \verb+figure+ and \verb+table+ respectively.  Figures
+and tables are separated from enclosing text by two horizontal rules
+(CSS~class \verb+floatrule+).  If the capabilities of \verb+floatrule+
+prove insufficient users can create their own separators by defining
+the parameter-less macro~\verb+\floatseparator+, like for example,
+
+\begin{verbatim}
+\newcommand{\floatseparator}{\begin{center}\ast\end{center}}
+\end{verbatim}
+
+\noindent or even drop them completely by supplying an empty expansion
+and thereby recover the original \LaTeX{} layout.
+
+Captions and cross referencing are handled.  However, captions are not
+moved at end of figures or tables: instead, they appear where the
+\verb+\caption+~commands occur in source.
+
+The \verb+\suppressfloats+ command does nothing; the figure related
+counters (such as \verb+topnumber+) exist but are useless.
+
+
+\subsection{Footnotes}
+
+The basics of footnotes are discussed in section~\ref{sec:footnotes}.
+
+\hevea{} puts the text of every footnote in a block associated with
+CSS~class \verb+footnotetext+.  The rule that separates the body text
+from the footnotes can by styled with CSS~class \verb+footnoterule+.
+
+
+\subsection{Marginal Notes}
 
 \comdefindex{marginpar}%
 \comdefindex{reversemarginpar}%

--- a/html/hevea.hva
+++ b/html/hevea.hva
@@ -106,7 +106,7 @@
 \newstyle{.thefootnotes}{text-align:left;margin:0ex;}
 \newstyle{.dt-thefootnotes}{margin:0em;}
 \newstyle{.dd-thefootnotes}{margin:0em 0em 0em 2em;}
-\newstyle{.footnoterule}{margin:1em auto 1em 0px;width:50\%;}
+\newstyle{.footnoterule}{background-color: black; border: none; height: 1px; margin: 1em auto 1em 0px; width: 40\%}
 \newcommand{\footnoterule}{\@hr[\envclass@attr{footnoterule}]{}{}}
 \newenvironment{thefootnotes}[2][]
   {\@out@par{{\@nostyle\@print{<!--BEGIN }\@getprint{#1}\@print{NOTES }\@getprint{\@footnotelevel}\@print{-->

--- a/latexcommon.hva
+++ b/latexcommon.hva
@@ -101,21 +101,37 @@
 \def\textsuperscript#1{\ensuremath{^{\mbox{#1}}}}
 %\def\textsubscript#1{\ensuremath{_{\mbox{#1}}}}%existe pas!
 %%%%% Figures and tables
-\setenvclass{figure}{figure}
 %%General \caption command: #1 -> env name, #2 -> \caption arg
-\newcommand{\hva@caption}[2]
-{\refstepcounter{#1}\begin{hva@capted}\csname #1name\endcsname{} \csname the#1\endcsname: #2\end{hva@capted}}
-\newcommand{\@figrule}{\begin{center}\@hr{.8\linewidth}{2pt}\end{center}}
-\newenvironment{figure}[1][]
-{\@forcecommand{\caption}[2][]{\hva@caption{figure}{##2}}%
-\@open@quote{\envclass@attr{figure}}\@figrule}
-{\@figrule\@close@quote}
+\newcommand{\hva@caption}[2]{%
+  \refstepcounter{#1}%
+  \begin{hva@capted}%
+    \csname #1name\endcsname{} \csname the#1\endcsname: #2%
+  \end{hva@capted}%
+}
+\newstyle{.floatrule}{background-color: black; border: none; height: 1px; width: 80\%}
+\setenvclass{floatrule}{floatrule}
+\newcommand{\@floatrule}{%
+  \ifu\floatseparator
+    \begin{center}%
+      \@hr[\envclass@attr{floatrule}]{}{}%
+    \end{center}%
+  \else
+    \floatseparator
+  \fi
+}
+\setenvclass{figure}{figure}
+\newenvironment{figure}[1][]{%
+  \@forcecommand{\caption}[2][]{\hva@caption{figure}{##2}}%
+  \@open@quote{\envclass@attr{figure}}%
+  \@floatrule
+}{\@floatrule\@close@quote}
 \newenvironment{figure*}[1][]{\begin{figure}[#1]}{\end{figure}}
 \setenvclass{table}{table}
-\newenvironment{table}[1][]
-{\@forcecommand{\caption}[2][]{\hva@caption{table}{##2}}%
-\@open@quote{\envclass@attr{table}}\@figrule%
-}{\@figrule\@close@quote}
+\newenvironment{table}[1][]{%
+  \@forcecommand{\caption}[2][]{\hva@caption{table}{##2}}%
+  \@open@quote{\envclass@attr{table}}%
+  \@floatrule
+}{\@floatrule\@close@quote}
 \newenvironment{table*}[1][]{\begin{table}[#1]}{\end{table}}
 \@forcecommand{\suppressfloats}[1][]{}
 \newcounter{topnumber}


### PR DESCRIPTION
Floating tables and figures are both decorated by `\@figrule` which reads
unintuitively for tables.  Therefore, this P/R renames `\@figrule` to `\@floatrule`.
The `hr` elements this macro controls get associated with CSS class `floatrule`.
Moreover, users can override the rule generation completely by defining
`\floatseparator`.  An empty expansion of `\floatseparator` recovers the
original LaTeX layout.  The P/R documents all the user-visible macros and
classes.

As footnotes are also a (special) kind of float document them in the relevant
section of the reference manual, too.
