### PR TITLE
Implement environment minipage with all four parameters

### DIFF
--- a/html/hevea.hva
+++ b/html/hevea.hva
@@ -388,22 +388,22 @@
   display: inline-block;
   text-indent: 0;
 }
-\def\@parbox@alignment@spec@bottom{b}
-\def\@parbox@alignment@spec@center{c}
-\def\@parbox@alignment@spec@top{t}
+\def\@box@alignment@spec@bottom{b}
+\def\@box@alignment@spec@center{c}
+\def\@box@alignment@spec@top{t}
 \RenewcommandHtml{\parbox}[3][]{%
   \def\@align{middle}%
   \def\@align@spec{#1}%
   \ife#1%
     \relax
   \else
-    \ifx\@parbox@alignment@spec@center
+    \ifx\@box@alignment@spec@center
       \relax
     \else
-      \ifx\@align@spec\@parbox@alignment@spec@bottom
+      \ifx\@align@spec\@box@alignment@spec@bottom
         \def\@align{text-bottom}%
       \else
-        \ifx\@align@spec\@parbox@alignment@spec@top
+        \ifx\@align@spec\@box@alignment@spec@top
           \def\@align{text-top}%
         \else
           \hva@warn{parbox: unknown alignment}%
@@ -814,11 +814,57 @@
 \newcommand{\underbrace}{\DisplayChoose\@underbrace\textunderbrace}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%concrete minipage
-\newstyle{.minipage}{text-align:left; margin-left:0em; margin-right:auto;}
-\setenvclass{minipage}{minipage}
-\newenvironment{@minipage}
-{\@open{div}{class="\getenvclass{minipage}"}}
-{\@close{div}}
+\newstyle{.minipage-container}{box-sizing: border-box; display: inline-block; position: relative;}
+\newstyle{.minipage}{box-sizing: border-box; display: inline-block; text-align: justify;}
+\newstyle{div.minipage p}{margin: 0; text-indent: 0;}
+\newenvironment{minipage@implementation}[4]{%
+  %--\hva@warn{minipage: 1: `#1', 2: `#2', 3: `#3', 4: `#4'}%
+  \def\@align{middle}%
+  \def\@align@spec{#1}%
+  \def\@inner@align@spec{#3}%
+  \ife#1%
+    \relax
+  \else
+    \ifx\@align@spec\@box@alignment@spec@center
+      \relax
+    \else
+      \ifx\@align@spec\@box@alignment@spec@bottom
+        \def\@align{text-bottom}%
+      \else
+        \ifx\@align@spec\@box@alignment@spec@top
+          \def\@align{text-top}%
+        \else
+          \hva@warn{minipage: unknown alignment}%
+        \fi
+      \fi
+    \fi
+  \fi
+  \def\@optional@inner@align{}%
+  \ife#2%
+    \def\@optional@height{}%
+  \else
+    \def\@optional@height{height:\css@length{#2};}%
+    \ife#3%
+      \relax
+    \else
+      \ifx\@inner@align@spec\@box@alignment@spec@center
+        \def\@optional@inner@align{ style="position: absolute; top: 50\%; transform: translateY(-50\%);"}
+      \else
+        \ifx\@inner@align@spec\@box@alignment@spec@bottom
+          \def\@optional@inner@align{ style="position: absolute; bottom: 0;"}
+        \else
+          \ifx\@inner@align@spec\@box@alignment@spec@top
+            \relax
+          \else
+            \hva@warn{minipage: unknown inner alignment}%
+          \fi
+        \fi
+      \fi
+    \fi
+  \fi
+  \@open{div}{class="minipage-container" style="\@optional@height vertical-align:\@align; width:\css@length{#4};"}%
+  \@open{div}{class="\getenvclass{minipage}"\@optional@inner@align}\@open@par}%
+{\@close{div}\@close{div}}
 %%%%%%%%margin par
 \newstyle{.marginpar}{border:solid thin black; margin-bottom:1ex; width:20\%; text-align:left;}
 \newstyle{.marginparleft}{float:left; clear:left; margin-left:0ex; margin-right:1ex;}

--- a/latexcommon.hva
+++ b/latexcommon.hva
@@ -708,13 +708,20 @@
 % 2. Flush notes at end
 \newcounter{mpfootnote}
 \renewcommand{\thempfootnote}{\alph{mpfootnote}}
-\newenvironment{minipage}[2][]
-  {\hva@warn{minipage, output may be poor}%
-  \renewcommand{\@footnotelevel}{document}\@footnotesub%
+\setenvclass{minipage}{minipage}
+\newcommand{\@minipage}[4]{%
+  \hva@warn{minipage -- layout may be poor}%
+  \begingroup
+  \renewcommand{\@footnotelevel}{document}\@footnotesub
   \setcounter{mpfootnote}{0}%
   \def\footnote@c{mpfootnote}%
-  \@minipage\@start@text}
-  {\@end@text\@footnoteflush@sticky{document}\@endfootnotesub\end@minipage}
+  \minipage@implementation{#1}{#2}{#3}{#4}\@start@text
+}
+\newcommand{\endminipage}{%
+  \@end@text\@footnoteflush@sticky{document}\@endfootnotesub
+  \endminipage@implementation
+  \endgroup
+}
 %%%%% Extension des environnments hevea en lecture de fichier
 \newcommand{\rawhtmlinput}[1]
 {\@scaninput{\begin{rawhtml}}{#1}{\end{rawhtml}}}

--- a/package.ml
+++ b/package.ml
@@ -398,7 +398,7 @@ def_code
   Scan.top_close_group ())
 ;;
 
-(* A few subst definitions, with 2 optional arguments *)
+(* A few subst definitions, with 2 or more optional arguments *)
 
 def "\\makebox" (latex_pat ["" ; ""] 3)
     (Subst ["\\@makebox{#1}{#2}{#3}"]) ;
@@ -414,6 +414,11 @@ def_code "\\raisebox"
         let dpth = get_prim_opt "" lexbuf in
           let text = get_prim_arg lexbuf in
             scan_this main ("\\@raisebox{" ^ raise_len ^ "}{" ^ hght ^ "}{" ^ dpth ^ "}{" ^ text ^ "}"))
+;;
+
+
+def "\\minipage" (latex_pat ["" ; ""; ""] 4)
+  (Subst ["\\@minipage{#1}{#2}{#3}{#4}"])
 ;;
 
 

--- a/text/hevea.hva
+++ b/text/hevea.hva
@@ -205,8 +205,7 @@
 \newcommand{\indexitem}{\item}
 \newcommand{\indexspace}{\vspace*{1em}}
 %%%%%%%%concrete minipage
-\setenvclass{minipage}{minipage}
-\newenvironment{@minipage}{}{}
+\newenvironment{minipage@implementation}[4]{}{}
 %%%%%%%%margin par
 \newif\ifmarginright\marginrighttrue
 \newcommand{\normalmarginpar}{\marginrighttrue}


### PR DESCRIPTION
tl;dr: minipage env now works with Hevea; layout still sucks.

Modern LaTeX allows for up to three optional parameters to be passed
to the environment `minipage` besides the mandatory argument `width`:

- `position`,
- `height`, and
- `content-position`.

This P/R implements a faithful translation for Hevea, which works for HTML
and text output modes.

The new `minipage` plays well with HTML flow, in particular it displays as
`inline-block`, but the fundamental problem of minipages not behaving as
"words" prevail.  See the attached sample file  [minipage-example.zip](https://github.com/maranget/hevea/files/5734440/minipage-example.zip) that
exercises almost all old and features.

To integrate manipages into the HTML flow and thus closely mimick the
LaTeX behavior more code is necessary.  I'm working on a prototype.
