### PR TITLE
OCaml 5 support: remove uses of deprecated functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ SUF=
 DIR=
 OCAMLC=$(DIR)ocamlc$(SUF)
 #OCAMLFLAGS=-w +a-4-9 -warn-error +a
-OCAMLFLAGS=-w +a-3-4-9-41-45-67
+OCAMLFLAGS=-w +a-4-9-41-45-67
 OCBFLAGS=-j 4 -classic-display
 
 #### End of configuration parameters

--- a/cut.mll
+++ b/cut.mll
@@ -697,7 +697,7 @@ rule main = parse
 |  "<!--" ("TOC"|"toc") blank+ (secname as arg) blank+
     ("id=" ((anchor as a)|('"' ([^'"']+ as a) '"')) blank+)? (* '"' *)
     {let sn =
-      if String.uppercase arg = "NOW" then !chapter
+      if String.uppercase_ascii arg = "NOW" then !chapter
       else Section.value arg in
     let name = tocline lexbuf in
     if verbose > 1 then begin
@@ -737,7 +737,7 @@ rule main = parse
      main lexbuf
     }
 | "<!--CUT DEF" ' '+ (secname as name) ' '* (['0'-'9']+ as i_opt)?
-    {let chapter = Section.value (String.uppercase name) in
+    {let chapter = Section.value (String.uppercase_ascii name) in
     let depth = match i_opt with
     | None -> !depth
     | Some s -> int_of_string s in

--- a/foot.ml
+++ b/foot.ml
@@ -98,8 +98,8 @@ let flush sticky lexer out sec_notes sec_here =
         all := ((mark,anchor),(themark,text)) :: !all)
       anchor_to_note ;
     all := List.sort
-        (fun (((m1:int),(a1:int)),_) ((m2,a2),_) -> match Pervasives.compare a1 a2 with
-        | 0 ->  Pervasives.compare m1 m2
+        (fun (((m1:int),(a1:int)),_) ((m2,a2),_) -> match Stdlib.compare a1 a2 with
+        | 0 ->  Stdlib.compare m1 m2
         | r -> r) !all ;
     List.iter
       (fun ((_,anchor),(themark,text)) ->

--- a/htmlCommon.ml
+++ b/htmlCommon.ml
@@ -113,7 +113,7 @@ let failclose s b1 b2=
                        string_of_block b2^"'"))
 
 let find_block s =
-  let s = String.lowercase s in
+  let s = String.lowercase_ascii s in
   try Hashtbl.find block_t s with
     | Not_found -> OTHER s
 

--- a/htmllex.mll
+++ b/htmllex.mll
@@ -60,7 +60,7 @@ let warnings = ref true
 
 let check_nesting _lb name =
   try
-    Hashtbl.find block (String.lowercase name) ;
+    Hashtbl.find block (String.lowercase_ascii name) ;
     if !txt_level <> 0 && !warnings then begin
       Location.print_fullpos () ;
       prerr_endline 
@@ -85,17 +85,17 @@ List.iter (init text)
 
 let is_textlevel name =
   try
-    let _ = Hashtbl.find text (String.lowercase name) in
+    let _ = Hashtbl.find text (String.lowercase_ascii name) in
     true
   with
   | Not_found -> false
 
-let is_br name = "br" = (String.lowercase name)
-let is_basefont name = "basefont" = (String.lowercase name)
+let is_br name = "br" = (String.lowercase_ascii name)
+let is_basefont name = "basefont" = (String.lowercase_ascii name)
 
 let set_basefont attrs lb = 
   List.iter
-    (fun (name,v,_) -> match String.lowercase name,v with
+    (fun (name,v,_) -> match String.lowercase_ascii name,v with
     | "size",Some s ->
         begin try
           Emisc.basefont := int_of_string s
@@ -123,7 +123,7 @@ let font_value lb v =
     let tag = String.sub v 0 k
     and v = String.sub v (k+1) (String.length v - (k+1)) in
     let tag =
-      match String.lowercase tag with
+      match String.lowercase_ascii tag with
       | "font-family" -> Ffamily
       | "font-style" -> Fstyle
       | "font-variant" -> Fvariant
@@ -148,7 +148,7 @@ let font_value lb v =
 let norm_attrs lb attrs =
    List.map
         (fun (name,value,txt) ->
-          match String.lowercase name with
+          match String.lowercase_ascii name with
           | "size" ->  SIZE (get_value lb value),txt
           | "color" -> COLOR (get_value lb value),txt
           | "face" -> FACE (get_value lb value),txt
@@ -162,7 +162,7 @@ let norm_attrs lb attrs =
     attrs
 
 let ouvre lb name attrs txt =
-  let uname = String.lowercase name in
+  let uname = String.lowercase_ascii name in
   try
     let tag = Hashtbl.find text uname in
     let attrs = norm_attrs lb attrs in
@@ -174,7 +174,7 @@ let ouvre lb name attrs txt =
 
 and ferme _lb name txt =
   try
-    let tag = Hashtbl.find text (String.lowercase name) in
+    let tag = Hashtbl.find text (String.lowercase_ascii name) in
     decr txt_level ;
     begin if not (MyStack.empty txt_stack) then
       let _  = MyStack.pop txt_stack in ()

--- a/htmltext.ml
+++ b/htmltext.ml
@@ -64,7 +64,7 @@ let size_val = function
   | "7" -> 7
   | _   -> raise No
 
-let color_val s = match String.lowercase s with
+let color_val s = match String.lowercase_ascii s with
 | "#000000" -> "black"
 | "#c0c0c0" -> "silver"
 | "#808080" -> "gray"

--- a/index.ml
+++ b/index.ml
@@ -141,7 +141,7 @@ let is_alpha c =  ('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z')
 
 let compare_char c1 c2 =
   if is_alpha c1 && is_alpha c2 then
-    let r = compare (Char.uppercase c1) (Char.uppercase c2) in
+    let r = compare (Char.uppercase_ascii c1) (Char.uppercase_ascii c2) in
     if r <> 0 then r
     else compare c1 c2
   else if is_alpha c1 then 1
@@ -239,7 +239,7 @@ let rec open_this out k = match k with
 let start_change s1 s2 = match s1,s2 with
 | "",_ -> false
 | _,"" -> false
-| _,_  -> Char.uppercase s1.[0] <> Char.uppercase s2.[0]
+| _,_  -> Char.uppercase_ascii s1.[0] <> Char.uppercase_ascii s2.[0]
 
 let print_entry out _ entries bk k xs  =
   let rp,rt = common bk k in

--- a/latexmacros.ml
+++ b/latexmacros.ml
@@ -15,12 +15,7 @@ open Lexstate
 
 exception Failed
 
-module OString = struct
-  type t = string
-  let compare = Pervasives.compare
-end
-
-module Strings = Set.Make (OString)
+module Strings = Set.Make (String)
 
 (* Data structures for TeX macro  model *)
 let local_table = Hashtbl.create 97

--- a/latexscan.mll
+++ b/latexscan.mll
@@ -948,13 +948,13 @@ let count_newlines s =
 ;;
 
 let check_case s = match !case with
-| Lower ->  String.lowercase s
-| Upper ->  String.uppercase s
+| Lower ->  String.lowercase_ascii s
+| Upper ->  String.uppercase_ascii s
 | Neutral -> s
 
 and check_case_char c = match !case with
-| Lower -> Char.lowercase c
-| Upper -> Char.uppercase c
+| Lower -> Char.lowercase_ascii c
+| Upper -> Char.uppercase_ascii c
 | Neutral -> c
 
 
@@ -3198,7 +3198,7 @@ let rec roman_of_int = function
      String.make d 'x'^roman_of_int u
 ;;
 
-let uproman_of_int i = String.uppercase (roman_of_int i)
+let uproman_of_int i = String.uppercase_ascii (roman_of_int i)
 ;;
 
 let fnsymbol_of_int = function

--- a/misc.ml
+++ b/misc.ml
@@ -58,7 +58,7 @@ let copy_hashtbl from_table to_table =
   let module OString =
     struct
       type t = string
-      let compare = Pervasives.compare
+      let compare = Stdlib.compare
     end in
   let module Strings = Set.Make (OString) in
   let keys = ref Strings.empty in

--- a/package.ml
+++ b/package.ml
@@ -1340,7 +1340,7 @@ let cr_sort_labels lbls =
   let ys =
     List.map
       (List.sort
-         (fun (_,o1) (_,o2) -> Pervasives.compare o1 o2)) ys in
+         (fun (_,o1) (_,o2) -> Stdlib.compare o1 o2)) ys in
   let lbls = List.map (List.map fst) ys in
   lbls
 ;;

--- a/pp.ml
+++ b/pp.ml
@@ -104,7 +104,7 @@ let as_fontstyle = function
 let fmtfontsyles fs =
   let fs =
     List.sort
-      (fun f1 f2 -> Pervasives.compare (as_fontstyle f1) (as_fontstyle f2))
+      (fun f1 f2 -> Stdlib.compare (as_fontstyle f1) (as_fontstyle f2))
       fs in
   sprintf " style=\"%s\"" (String.concat ";" (List.map fmtfontsyle fs))
 

--- a/section.ml
+++ b/section.ml
@@ -15,7 +15,7 @@ type style = Article | Book
 
 let style = ref Book
 
-let set_style sty = match String.uppercase sty with
+let set_style sty = match String.uppercase_ascii sty with
 | "ARTICLE" -> style := Article
 | "BOOK" -> style := Book
 | _ ->
@@ -52,7 +52,7 @@ let value s =
   (match !style with
   | Article -> value_article
   | Book -> value_book)
-    (String.uppercase s)
+    (String.uppercase_ascii s)
 
 let pretty_article = function
 | 0 -> "document"

--- a/subst.mll
+++ b/subst.mll
@@ -151,7 +151,7 @@ let translate f s =
   let lexbuf = MyLexing.from_string s in
   do_translate lexbuf f
 
-let lowercase s = translate Char.lowercase s
-and uppercase s = translate Char.uppercase s
+let lowercase s = translate Char.lowercase_ascii s
+and uppercase s = translate Char.uppercase_ascii s
 
 } 

--- a/text.ml
+++ b/text.ml
@@ -70,7 +70,7 @@ let () =
     blocks
 
 let tr_block s a =
-  let s = String.uppercase s in
+  let s = String.uppercase_ascii s in
   try
     Hashtbl.find s2b s
   with Not_found ->
@@ -762,7 +762,7 @@ let try_open_block s args =
 	finit_ligne ();	
 	flags.in_align<-true;
 	flags.first_line <-2;
-	match String.uppercase args with
+	match String.uppercase_ascii args with
 	  "LEFT" -> flags.align <- Left
 	| "CENTER" -> flags.align <- Center
 	| "RIGHT" -> flags.align <- Right
@@ -907,7 +907,7 @@ let close_flow s =
 ;;
 
 
-let insert_block _ arg =  match String.uppercase arg with
+let insert_block _ arg =  match String.uppercase_ascii arg with
 | "LEFT" -> flags.align <- Left
 | "CENTER" -> flags.align <- Center
 | "RIGHT" -> flags.align <- Right

--- a/ultra.ml
+++ b/ultra.ml
@@ -293,7 +293,7 @@ let select_factors fs =
     prerr_string "fs3:" ; pfactorc stderr fs3
   end ;
   List.sort
-    (fun ((_,j1),_) ((i2,_),_) -> Pervasives.compare (j1:int) i2)
+    (fun ((_,j1),_) ((i2,_),_) -> Stdlib.compare (j1:int) i2)
     (get_them fs3)
 
 

--- a/verb.mll
+++ b/verb.mll
@@ -179,8 +179,8 @@ let dest_string = Scan.translate_put_unicode_string
 let dest_case s =
   Dest.put
     (match !case with
-    | Upper -> String.uppercase s
-    | Lower -> String.lowercase s
+    | Upper -> String.uppercase_ascii s
+    | Lower -> String.lowercase_ascii s
     | _     -> s)
 
 (* Keywords *)


### PR DESCRIPTION
This PR replaces the deprecated functions that were removed in OCaml 5 by their OCaml ≥4.08 equivalent.
It also sneakily enable the deprecation warning. 