### PR TITLE
[hevea] Fix end comment

### DIFF
--- a/bugs/015/a.tex
+++ b/bugs/015/a.tex
@@ -1,0 +1,13 @@
+%Reported by Moshen Banan
+\documentclass{article}
+\usepackage{comment}
+
+\excludecomment{whenBuildMayDay2025Int}
+
+\begin{document}
+
+\begin{whenBuildMayDay2025Int}
+Conditional text comes here
+\end{whenBuildMayDay2025Int}
+
+\end{document}

--- a/verb.mll
+++ b/verb.mll
@@ -861,7 +861,7 @@ and scan_byline process finish = parse
      if (not !input_verb || MyStack.empty stack_lexbuf)
         && env = !Scan.cur_env then begin
       finish () ;
-      scan_this Scan.main ("\\end"^env) ;
+      scan_this Scan.main ("\\csname end"^env^"\\endcsname") ;
       Scan.top_close_block "" ;
       Scan.close_env !Scan.cur_env ;
       ()

--- a/version.ml
+++ b/version.ml
@@ -9,8 +9,8 @@
 (*                                                                     *)
 (***********************************************************************)
 
-let real_version = "2.36"
-let release_date = "2022-06-15"
+let real_version = "2.36+1"
+let release_date = "2025-05-14"
 
 let version =
   try


### PR DESCRIPTION
Bug fix. The following code failed:
```
% cat a.tex
\documentclass{article}
\usepackage{comment}

\excludecomment{whenBuildMayDay2025Int}

\begin{document}

\begin{whenBuildMayDay2025Int}
Conditional text comes here
\end{whenBuildMayDay2025Int}

\end{document}
% /bin/hevea -fix -O a.tex
Exclude comment 'comment'
Exclude comment 'whenBuildMayDay2025Int'
./a.tex:10: Warning: Command not found: \endwhenBuildMayDay
Fixpoint reached in 1 step(s)
```

Fix consists in using the `\csname ... \endcsname` construct for scanning the `\end...` command at the end
of excluded comment scanning. 