### PR TITLE
Allow Makefile to support windows path passed as PREFIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,11 @@ TARGET=opt
 # Install prefix
 PREFIX?=/usr/local
 # Library directory of hevea
-LIBDIR=$(PREFIX)/lib/hevea
+LIBDIR="$(PREFIX)/lib/hevea"
 # Where to install programms
-BINDIR=$(PREFIX)/bin
+BINDIR="$(PREFIX)/bin"
 #Where to install hevea.sty
-LATEXLIBDIR=$(PREFIX)/lib/hevea
+LATEXLIBDIR="$(PREFIX)/lib/hevea"
 ##### Advanced configuration parameters
 SUF=
 DIR=
@@ -40,9 +40,9 @@ config.sh: Makefile libs.def handle402.sh
 	@( cat handle402.sh &&\
 	echo PGM=\"$(PGM)\" &&\
 	echo PGMNATIVE=\"$(PGMNATIVE)\" &&\
-	echo BINDIR=$(BINDIR) &&\
-	echo LIBDIR=$(LIBDIR) &&\
-	echo LATEXLIBDIR=$(LATEXLIBDIR) &&\
+	echo BINDIR=\"$(BINDIR)\" &&\
+	echo LIBDIR=\"$(LIBDIR)\" &&\
+	echo LATEXLIBDIR=\"$(LATEXLIBDIR)\" &&\
 	echo OCAMLFLAGS=\"$(OCAMLFLAGS)\" &&\
 	echo OCBFLAGS=\"$(OCBFLAGS)\" &&\
 	echo ALLLIB=\"$(ALLLIB)\" && \

--- a/expandlib.sh
+++ b/expandlib.sh
@@ -1,3 +1,4 @@
 #! /bin/sh
 . `dirname $0`/config.sh
+LIBDIR=$(echo "$LIBDIR" | sed -e 's|\\|/|g')
 sed -e "s,LIBDIR,$LIBDIR,g" $1


### PR DESCRIPTION
This PR is serve generally for opam on windows that when installing hevea passes windows-style path. When generating config.sh this path isn't quoted, so "\\" are escaped and that results in invalid path.