### PR TITLE
Add local OPAM file

### DIFF
--- a/hevea.opam
+++ b/hevea.opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+name: "hevea"
+version: "2.38"
+maintainer: "Luc Maranget <Luc.Maranget@inria.fr>"
+authors: "Luc Maranget"
+homepage: "http://hevea.inria.fr/"
+bug-reports: "https://github.com/maranget/hevea/issues/"
+doc: "http://hevea.inria.fr/doc/index.html"
+dev-repo: "git+https://github.com/maranget/hevea.git"
+license: ["QPL-1.0 WITH OCaml-LGPL-linking-exception"]
+build: [make "PREFIX=%{prefix}%"]
+install: [make "PREFIX=%{prefix}%" "install"]
+post-messages: [
+  "The file 'hevea.sty' has been installed in %{lib}%/hevea but latex won't see it by itself" {success}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlbuild" {build}
+]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
+synopsis: "A quite complete and fast LATEX to HTML translator"


### PR DESCRIPTION
So that `opam pin .` installs the current working version of Hevea.

Also: fixed the "bug report" URL.
