### PR TITLE
Implement some special fonts with Unicode entities

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -6,6 +6,8 @@
 *.htoc
 *.log
 *.bbl
+*.fls
+*.fdb_latexmk
 *.dvi
 *.hind
 *.bbl

--- a/examples/st.hva
+++ b/examples/st.hva
@@ -83,7 +83,7 @@
 \def\idxCTAN{}
 \newcommand{\vphantom}[1]{#1}
 \renewcommand{\hbox}[1]{}
-\newcommand{\AMS}{\mbox{\cal{}AMS}}
+\newcommand{\AMS}{AMS}
 \iftext\usepackage[latin1]{inputenc}\fi
 \renewcommand{\cite}[1]{}
 \newcommand{\unavail}[1]{No}

--- a/html/amsfonts.hva
+++ b/html/amsfonts.hva
@@ -1,7 +1,6 @@
-\def\@mathbb#1{%
-\ifx#1\@empty\let\@next\@empty\else\@doublestruck#1\let\@next\@mathbb\fi
-\@next}
-\newcommand{\mathbb}[1]{\@callprim{\@mathbb}{#1\@print{\@empty}}}
+\@primitives{amsfonts}
+\def\mathbb{\apply@chars{\one@mathbb}}
+\def\frak{\apply@chars{\one@frak}}
 \DeclareSymbolHtml{\ulcorner}{X231C}
 \DeclareSymbolHtml{\urcorner}{X231D}
 \DeclareSymbolHtml{\llcorner}{X231E}

--- a/html/common-math.hva
+++ b/html/common-math.hva
@@ -173,47 +173,6 @@
 \ifthenelse{\equal{#1}{0}}{\@print{0}}{%
 }}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}%
 %%%
-%%% Calligraphic letters (no lowercase)
-%%%
-\newcommand{\one@mathcal}[1]{%
-\ifthenelse{\equal{#1}{A}}{\@print{&#119964;}}{%
-\ifthenelse{\equal{#1}{B}}{\@print{&#119965;}}{% not currently supported 
-\ifthenelse{\equal{#1}{C}}{\@print{&#119966;}}{%
-\ifthenelse{\equal{#1}{D}}{\@print{&#119967;}}{%
-\ifthenelse{\equal{#1}{E}}{\@print{&#119968;}}{% not currently supported
-\ifthenelse{\equal{#1}{F}}{\@print{&#119969;}}{% not currently supported
-\ifthenelse{\equal{#1}{G}}{\@print{&#119970;}}{%
-\ifthenelse{\equal{#1}{H}}{\@print{&#119971;}}{% not currently supported
-\ifthenelse{\equal{#1}{I}}{\@print{&#119972;}}{% not currently supported
-\ifthenelse{\equal{#1}{J}}{\@print{&#119973;}}{%
-\ifthenelse{\equal{#1}{K}}{\@print{&#119974;}}{%
-\ifthenelse{\equal{#1}{L}}{\@print{&#119975;}}{% not currently supported
-\ifthenelse{\equal{#1}{M}}{\@print{&#119976;}}{% not currently supported
-\ifthenelse{\equal{#1}{N}}{\@print{&#119977;}}{%
-\ifthenelse{\equal{#1}{O}}{\@print{&#119978;}}{%
-\ifthenelse{\equal{#1}{P}}{\@print{&#119979;}}{%
-\ifthenelse{\equal{#1}{Q}}{\@print{&#119980;}}{%
-\ifthenelse{\equal{#1}{R}}{\@print{&#119981;}}{% not currently supported
-\ifthenelse{\equal{#1}{S}}{\@print{&#119982;}}{%
-\ifthenelse{\equal{#1}{T}}{\@print{&#119983;}}{%
-\ifthenelse{\equal{#1}{U}}{\@print{&#119984;}}{%
-\ifthenelse{\equal{#1}{V}}{\@print{&#119985;}}{%
-\ifthenelse{\equal{#1}{W}}{\@print{&#119986;}}{%
-\ifthenelse{\equal{#1}{X}}{\@print{&#119987;}}{%
-\ifthenelse{\equal{#1}{Y}}{\@print{&#119988;}}{%
-\ifthenelse{\equal{#1}{Z}}{\@print{&#119989;}}{%
-\ifthenelse{\equal{#1}{1}}{\@print{1}}{%
-\ifthenelse{\equal{#1}{2}}{\@print{2}}{%
-\ifthenelse{\equal{#1}{3}}{\@print{3}}{%
-\ifthenelse{\equal{#1}{4}}{\@print{4}}{%
-\ifthenelse{\equal{#1}{5}}{\@print{5}}{%
-\ifthenelse{\equal{#1}{6}}{\@print{6}}{%
-\ifthenelse{\equal{#1}{7}}{\@print{7}}{%
-\ifthenelse{\equal{#1}{8}}{\@print{8}}{%
-\ifthenelse{\equal{#1}{9}}{\@print{9}}{%
-\ifthenelse{\equal{#1}{0}}{\@print{0}}{%
-}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}%
-%%%
 %%% Typewriter style letters (allows lowercase and digits)
 %%%
 \newcommand{\one@mathtt}[1]{%

--- a/html/hevea.hva
+++ b/html/hevea.hva
@@ -263,6 +263,11 @@
 \renewcommand{\&}{\ifraw\@print{&}\else\@print{&amp;}\fi}
 \renewcommand{\textless}{\ifraw\@print{<}\else\@print{&lt;}\fi}
 \renewcommand{\textgreater}{\ifraw\@print{>}\else\@print{&gt;}\fi}
+%redefine mathcal
+\let\old@mathcal\mathcal
+\newcommand{\mathcal@default}[1]
+{\hva@warn{applying \mathcal@default on #1}\old@mathcal{#1}}
+\def\mathcal{\apply@chars{\one@mathcal}}
 %%%%%%%%%%%% Bibliography
 \newcommand{\@bibtagstyle}{}
 \newcommand{\@bibref}[3]

--- a/outUnicode.ml
+++ b/outUnicode.ml
@@ -756,66 +756,147 @@ and doublestruck = function
   | 'Q' -> 0x211A
   | 'R' -> 0x211D
   | 'Z' -> 0x2124
-  | 'D' -> 0x2145
+  | 'D' -> 0x1D53B
   | 'd' -> 0x2146
   | 'e' -> 0x2147
   | 'i' -> 0x2148
   | 'j' -> 0x2149
-  |  c ->
-      if !Parse_opts.moreentities then begin match c with
-      | 'A' -> 0x1D538
-      | 'B' -> 0x1D539
-      | 'E' -> 0x1D53C
-      | 'F' -> 0x1D53D
-      | 'G' -> 0x1D53E
-      | 'I' -> 0x1D540
-      | 'J' -> 0x1D541
-      | 'K' -> 0x1D542
-      | 'L' -> 0x1D543
-      | 'M' -> 0x1D544
-      | 'O' -> 0x1D546
-      | 'S' -> 0x1D54A
-      | 'T' -> 0x1D54B
-      | 'U' -> 0x1D54C
-      | 'V' -> 0x1D54D
-      | 'W' -> 0x1D54E
-      | 'X' -> 0x1D54F
-      | 'Y' -> 0x1D550
-      | 'a' -> 0x1D552
-      | 'b' -> 0x1D553
-      | 'c' -> 0x1D554
-      | 'f' -> 0x1D557
-      | 'g' -> 0x1D558
-      | 'h' -> 0x1D559
-      | 'k' -> 0x1D55C
-      | 'l' -> 0x1D55D
-      | 'm' -> 0x1D55E
-      | 'n' -> 0x1D55F
-      | 'o' -> 0x1D560
-      | 'p' -> 0x1D561
-      | 'q' -> 0x1D562
-      | 'r' -> 0x1D563
-      | 's' -> 0x1D564
-      | 't' -> 0x1D565
-      | 'u' -> 0x1D566
-      | 'v' -> 0x1D567
-      | 'w' -> 0x1D568
-      | 'x' -> 0x1D569
-      | 'y' -> 0x1D56A
-      | 'z' -> 0x1D56B
-      | '0' -> 0x1D7D8
-      | '1' -> 0x1D7D9
-      | '2' -> 0x1D7DA
-      | '3' -> 0x1D7DB
-      | '4' -> 0x1D7DC
-      | '5' -> 0x1D7DD
-      | '6' -> 0x1D7DE
-      | '7' -> 0x1D7DF
-      | '8' -> 0x1D7E0
-      | '9' -> 0x1D7E1
-      | _ -> raise CannotTranslate
-      end else
-        raise CannotTranslate
+  | 'A' -> 0x1D538
+  | 'B' -> 0x1D539
+  | 'E' -> 0x1D53C
+  | 'F' -> 0x1D53D
+  | 'G' -> 0x1D53E
+  | 'I' -> 0x1D540
+  | 'J' -> 0x1D541
+  | 'K' -> 0x1D542
+  | 'L' -> 0x1D543
+  | 'M' -> 0x1D544
+  | 'O' -> 0x1D546
+  | 'S' -> 0x1D54A
+  | 'T' -> 0x1D54B
+  | 'U' -> 0x1D54C
+  | 'V' -> 0x1D54D
+  | 'W' -> 0x1D54E
+  | 'X' -> 0x1D54F
+  | 'Y' -> 0x1D550
+  | 'a' -> 0x1D552
+  | 'b' -> 0x1D553
+  | 'c' -> 0x1D554
+  | 'f' -> 0x1D557
+  | 'g' -> 0x1D558
+  | 'h' -> 0x1D559
+  | 'k' -> 0x1D55C
+  | 'l' -> 0x1D55D
+  | 'm' -> 0x1D55E
+  | 'n' -> 0x1D55F
+  | 'o' -> 0x1D560
+  | 'p' -> 0x1D561
+  | 'q' -> 0x1D562
+  | 'r' -> 0x1D563
+  | 's' -> 0x1D564
+  | 't' -> 0x1D565
+  | 'u' -> 0x1D566
+  | 'v' -> 0x1D567
+  | 'w' -> 0x1D568
+  | 'x' -> 0x1D569
+  | 'y' -> 0x1D56A
+  | 'z' -> 0x1D56B
+  | '0' -> 0x1D7D8
+  | '1' -> 0x1D7D9
+  | '2' -> 0x1D7DA
+  | '3' -> 0x1D7DB
+  | '4' -> 0x1D7DC
+  | '5' -> 0x1D7DD
+  | '6' -> 0x1D7DE
+  | '7' -> 0x1D7DF
+  | '8' -> 0x1D7E0
+  | '9' -> 0x1D7E1
+  | _ -> raise CannotTranslate
+
+and calligraphic = function
+  | 'A' -> 0x1D49C
+  | 'B' -> 0x212C
+  | 'C' -> 0x1D49E
+  | 'D' -> 0x1D49F
+  | 'E' -> 0x2130
+  | 'F' -> 0x2131
+  | 'G' -> 0x1D4A2
+  | 'H' -> 0x210B
+  | 'I' -> 0x2110
+  | 'J' -> 0x1D4A5
+  | 'K' -> 0x1D4A6
+  | 'L' -> 0x2112
+  | 'M' -> 0x2133
+  | 'N' -> 0x1D4A9
+  | 'O' -> 0x1D4AA
+  | 'P' -> 0x1D4AB
+  | 'Q' -> 0x1D4AC
+  | 'R' -> 0x211B
+  | 'S' -> 0x1D4AE
+  | 'T' -> 0x1D4AF
+  | 'U' -> 0x1D4B0
+  | 'V' -> 0x1D4B1
+  | 'W' -> 0x1D4B2
+  | 'X' -> 0x1D4B3
+  | 'Y' -> 0x1D4B4
+  | 'Z' -> 0x1D4B5
+  | _ -> raise CannotTranslate
+
+and fraktur = function
+  | 'A' -> 0x1D56C
+  | 'B' -> 0x1D56D
+  | 'C' -> 0x1D56E
+  | 'D' -> 0x1D56F
+  | 'E' -> 0x1D570
+  | 'F' -> 0x1D571
+  | 'G' -> 0x1D572
+  | 'H' -> 0x1D573
+  | 'I' -> 0x1D574
+  | 'J' -> 0x1D575
+  | 'K' -> 0x1D576
+  | 'L' -> 0x1D577
+  | 'M' -> 0x1D578
+  | 'N' -> 0x1D579
+  | 'O' -> 0x1D57A
+  | 'P' -> 0x1D57B
+  | 'Q' -> 0x1D57C
+  | 'R' -> 0x1D57D
+  | 'S' -> 0x1D57E
+  | 'T' -> 0x1D57F
+  | 'U' -> 0x1D580
+  | 'V' -> 0x1D581
+  | 'W' -> 0x1D582
+  | 'X' -> 0x1D583
+  | 'Y' -> 0x1D584
+  | 'Z' -> 0x1D585
+  | 'a' -> 0x1D586
+  | 'b' -> 0x1D587
+  | 'c' -> 0x1D588
+  | 'd' -> 0x1D589
+  | 'e' -> 0x1D58A
+  | 'f' -> 0x1D58B
+  | 'g' -> 0x1D58C
+  | 'h' -> 0x1D58D
+  | 'i' -> 0x1D58E
+  | 'j' -> 0x1D58F
+  | 'k' -> 0x1D590
+  | 'l' -> 0x1D591
+  | 'm' -> 0x1D592
+  | 'n' -> 0x1D593
+  | 'o' -> 0x1D594
+  | 'p' -> 0x1D595
+  | 'q' -> 0x1D596
+  | 'r' -> 0x1D597
+  | 's' -> 0x1D598
+  | 't' -> 0x1D599
+  | 'u' -> 0x1D59A
+  | 'v' -> 0x1D59B
+  | 'w' -> 0x1D59C
+  | 'x' -> 0x1D59D
+  | 'y' -> 0x1D59E
+  | 'z' -> 0x1D59F
+  | _ -> raise CannotTranslate
+
 (* Text rendering *)
 let def_t = Hashtbl.create 101
 

--- a/outUnicode.mli
+++ b/outUnicode.mli
@@ -53,7 +53,8 @@ val ringabove : char -> unichar
 val ogonek : char -> unichar
 val circled : char -> unichar
 val doublestruck : char -> unichar
-
+val calligraphic : char -> unichar
+val fraktur : char -> unichar
 
 (* Default rendering *)
 val def_default : unichar -> string -> unit


### PR DESCRIPTION
Better implementation of \mathcal, \mathbb and \frak. The commands \mathbb and \frak are parts of the package 'amsfonts'