### PR TITLE
Handle \i and \j as arguments of accent commands

### DIFF
--- a/outUnicode.ml
+++ b/outUnicode.ml
@@ -333,7 +333,8 @@ and acute = function
   | 'p' -> 0x1E55
   | 'W' -> 0x1E82
   | 'w' -> 0x1E83
-  | _ -> raise CannotTranslate
+  | _ ->
+      raise CannotTranslate
 
 and circumflex = function
   | 'A' -> 0x00C2
@@ -975,26 +976,20 @@ let comb_cedilla = function
   | 'o'|'O' -> 0x0327
   | _ -> raise CannotTranslate
 
-let comb_grave = function
-  | 'j'|'J' -> 0x0300
+let comb_alpha ent c =
+  match c with
+  | 'a'..'z'|'A'..'Z' -> ent
   | _ -> raise CannotTranslate
 
-let comb_acute = function
-  | 'j'|'J' -> 0x0301
-  | _ -> raise CannotTranslate
+let comb_grave = comb_alpha 0x0300
 
+let comb_acute = comb_alpha 0x0301  
 
+let comb_circumflex = comb_alpha 0x0302
+
+let comb_tilde = comb_alpha 0x0303
 
 (* Double accents *)
 
 let double_inverted_breve = 0x0361
 
-(* Accent over numerical entities  *)
-
-let tr_entity = function
-  | "&#X131;"|"&#305;" -> 'i'
-  | "&#X237;"|"&#567;" -> 'j'
-  | _ -> raise CannotTranslate
-
-let on_entity put_char put_unicode f optg empty s =
-  apply_accent  put_char put_unicode f optg empty (tr_entity s)

--- a/outUnicode.mli
+++ b/outUnicode.mli
@@ -117,12 +117,8 @@ val rtprime : unichar
 val comb_cedilla : char -> unichar
 val comb_grave : char -> unichar
 val comb_acute : char -> unichar
+val comb_circumflex : char -> unichar
+val comb_tilde : char -> unichar
 
 (* Double diacritics *)
 val double_inverted_breve : unichar
-
-(* Apply accent on unicode entity *)
-val on_entity :
-    (char -> unit) -> (unichar -> unit) ->
-      (char -> unichar) -> (char -> unichar) option ->
-        unichar -> string -> unit


### PR DESCRIPTION
Handle dotless i and j (resp. \i and \j) as arguments of the accents commands.

Also use combining diacritics to add accents on all letters for some frequent accents (acute, grave, circumflex and tilde).