### PR TITLE
Replicate space when eaten after \mathop

### DIFF
--- a/latexscan.mll
+++ b/latexscan.mll
@@ -1588,45 +1588,29 @@ def_code "\\@hevea@circ" (fun lexbuf -> sub_sup '^' lexbuf)
 ;;
 
 def_code "\\mathop"
-  (fun lexbuf ->
-    let symbol = save_arg lexbuf in
-    let {limits=limits ; sup=sup ; sub=sub} = save_sup_sub lexbuf in
-    begin match limits with
-    | (Some Limits|None) when !display ->
-        Dest.limit_sup_sub
-          (scan_this_arg main)
-          (fun _ -> scan_this_arg main symbol) sup sub !display
-    | (Some IntLimits) when !display ->
-        Dest.int_sup_sub true 3
-          (scan_this_arg main)
-          (fun () -> scan_this_arg main symbol)
-          sup sub !display        
-    | _ ->
-        scan_this_arg main symbol ;
-        Dest.standard_sup_sub
-          (scan_this_arg main)
-          (fun _ -> ()) sup sub !display
-    end) ;
-def_code "\\@mathop"
-  (fun lexbuf ->
-    let symbol = save_arg lexbuf in
-    let {limits=limits ; sup=sup ; sub=sub} = save_sup_sub lexbuf in
-    begin match limits with
-    | (Some Limits) when !display ->
-        Dest.limit_sup_sub
-          (scan_this_arg main)
-          (fun _ -> scan_this_arg main symbol) sup sub !display
-    | (Some IntLimits|None) when !display ->
-        Dest.int_sup_sub true 3
-          (scan_this_arg main)
-          (fun () -> scan_this_arg main symbol)
-          sup sub !display        
-    | _ ->
-        scan_this_arg main symbol ;
-        Dest.standard_sup_sub
-          (scan_this_arg main)
-          (fun _ -> ()) sup sub !display
-    end)
+  begin
+    let add_space space =  if space then scan_this main " "  in
+    (fun lexbuf ->
+       let symbol = save_arg lexbuf in
+       let {limits; space; sup; sub; } = save_sup_sub lexbuf in
+       begin match limits with
+         | (Some Limits|None) when !display ->
+             Dest.limit_sup_sub
+               (scan_this_arg main)
+               (fun _ -> scan_this_arg main symbol) sup sub !display
+         | (Some IntLimits) when !display ->
+             Dest.int_sup_sub true 3
+               (scan_this_arg main)
+               (fun () -> scan_this_arg main symbol)
+               sup sub !display
+         | _ ->
+             scan_this_arg main symbol ;
+             add_space space ;
+             Dest.standard_sup_sub
+               (scan_this_arg main)
+               (fun _ -> ()) sup sub !display
+       end)
+  end
 ;;
 
 

--- a/lexstate.mli
+++ b/lexstate.mli
@@ -107,6 +107,7 @@ val end_normal : unit -> unit
 (* Super/Sub-script parsing *)
   type sup_sub = {
     limits : Misc.limits option;
+    space : bool; (* Some space has been eaten *)
     sup : string arg;
     sub : string arg;
   } 

--- a/save.mli
+++ b/save.mli
@@ -22,7 +22,7 @@ val seen_par : bool ref
 val gobble_one_char : Lexing.lexbuf -> unit
 
 exception Eof
-exception LimitEof of Misc.limits option
+exception LimitEof of Misc.limits option * bool
 exception NoOpt
 
 val get_echo : unit -> string
@@ -44,7 +44,8 @@ val check_equal : Lexing.lexbuf -> bool
 val filename : Lexing.lexbuf -> string
 val remain : Lexing.lexbuf -> string
 (* Superscript and subscripts *)
-val get_limits : Misc.limits option -> Lexing.lexbuf -> Misc.limits option
+val get_limits :
+  Misc.limits option -> bool -> Lexing.lexbuf -> Misc.limits option * bool
 val get_sup : Lexing.lexbuf -> string option
 val get_sub : Lexing.lexbuf -> string option
 

--- a/save.mll
+++ b/save.mll
@@ -229,13 +229,13 @@ and filename = parse
 and remain = parse
  _ * eof {Lexing.lexeme lexbuf}
 
-and get_limits r = parse
-  space+        {get_limits r lexbuf}
-| "\\limits"    {get_limits (Some Limits) lexbuf}
-| "\\nolimits"  {get_limits (Some NoLimits) lexbuf}
-| "\\intlimits" {get_limits (Some IntLimits) lexbuf}
-| eof           {raise (LimitEof r)}
-| ""            {r}
+and get_limits r some_space = parse
+  space+        {get_limits r true lexbuf}
+| "\\limits"    {get_limits (Some Limits) some_space lexbuf}
+| "\\nolimits"  {get_limits (Some NoLimits) some_space lexbuf}
+| "\\intlimits" {get_limits (Some IntLimits) some_space lexbuf}
+| eof           {raise (LimitEof (r,some_space))}
+| ""            {r,some_space}
 
 and get_sup = parse
 | space* '^'  {try Some (Saver.String.arg lexbuf) with Eof -> error "End of file after ^"}

--- a/saveUtils.ml
+++ b/saveUtils.ml
@@ -59,7 +59,7 @@ let my_int_of_string s =
 
 exception Eof
 ;;
-exception LimitEof of Misc.limits option
+exception LimitEof of Misc.limits option * bool
 ;;
 exception NoOpt
 ;;


### PR DESCRIPTION
Space after \mathop can be lexed out while searching for limit specification. If so, add one space in output.