### PR TITLE
Fix listing bug

### DIFF
--- a/bugs/016/a.tex
+++ b/bugs/016/a.tex
@@ -1,0 +1,41 @@
+\documentclass{article}
+\usepackage{color}
+\usepackage{listings}
+
+\lstdefinelanguage{ASL}
+{
+  morekeywords={begin,
+    var,
+    end},
+    morecomment=[l][\color{blue}]{//},
+    morecomment=[s][\color{blue}]{/*}{*/},
+    morestring=[b][\color{cyan}]",
+    morestring=[d][\color{cyan}]',
+}
+\definecolor{lightyellow}{cmyk}{0.0, 0.0, 0.20, 0.0}
+
+\lstset{
+  keywordstyle=\bf,
+}
+
+\begin{document}
+Keywords un bold. Previously, only the first keyword was recognised as such when the list of key words was given with newlines after commas. For instance:
+\begin{verbatim}
+\lstset{
+keywords={begin,
+  var,
+  end
+}
+\end{verbatim}
+
+\begin{lstlisting}[language=ASL]
+  begin
+// Variable declaration   
+    var x = 1;
+  end
+\end{lstlisting}
+
+\begin{lstlisting}[language=Caml]
+let x = 1
+\end{lstlisting}
+\end{document}

--- a/listings.hva
+++ b/listings.hva
@@ -88,7 +88,7 @@
   \@callprim{\lst@delete@directives}{\{\lst@alldirectives\}}}
 \def\lst@install@kwd#1#2{%
 %\hva@warn{INSTALL: #2 -> #1}%
-\def\csname lstk@\lst@normalize{#2}\endcsname{#1}}
+\def\csname lstk@\lst@normalize{\lst@eatspaces{#2}}\endcsname{#1}}
 \def\lst@install@kwds#1#2{%
 %     \hva@warn{RESET: «#1»}%
     \lst@delete@kwd@class{#1}%
@@ -98,7 +98,7 @@
 %    \hva@warn{MORE: «#1»}%
     \lst@record@kwd@class{#1}{#2}%
     \lst@iter{\lst@install@kwd{\csname lst@keywordstyle#1\endcsname}}{#2}}
-\def\lst@install@directive#1#2{\def\csname lstd@\lst@normalize{#2}\endcsname{#1}}
+\def\lst@install@directive#1#2{\def\csname lstd@\lst@normalize{\lst@eatspaces{#2}}\endcsname{#1}}
 \def\lst@install@directives
   #1#2{%
     \lst@directivestrue%
@@ -696,6 +696,9 @@ breakindent,breakautoindent}
 \def\lst@output@space{\stepcounter{lst@spaces}}
 \lst@AddToHook{Init}{\setcounter{lst@spaces}{0}}
 \newsavebox{\normalize@box}
+%Eat space(s) before keywords references
+\newcommand{\lst@eatspaces}[1]{\@callprim{\@eatspaces}{#1,}}
+%In case if case insensitive
 \def\lst@normalize#1{%
   \sbox{\normalize@box}
   {\iflst@sensitive\@rawchars{#1}\else\@rawchars{\MakeLowercase{#1}}\fi}%


### PR DESCRIPTION
Spaces after commas in keywords list were included in keyword reference. As for instance in:
```
\lstset{%
  keywords={%
    begin,
    end}
```
The bug resulted in some keywords not being recognised and thus not being typeset.