### PR TITLE
Document option -fix0

### DIFF
--- a/doc/hevea.1
+++ b/doc/hevea.1
@@ -62,6 +62,11 @@ then read its result.
 Iterate Hevea until reaching a fixpoint.  This option does not work in
 \(lqFilter Mode\(rq.
 .TP
+.B \-fix0
+Like
+.BR \-fix ,
+but restricts Hevea to run exactly once.
+.TP
 .B \-francais
 French mode (deprecated).
 .TP


### PR DESCRIPTION
Add the new command-line option of Hevea `-fix0`
to the manual page.
