### PR TITLE
Avoid warning when underscore present in label

### DIFF
--- a/labeltype.hva
+++ b/labeltype.hva
@@ -9,7 +9,7 @@
 \let\@rt@old@label\label
 \renewcommand{\label}[2][]
 {\@rt@old@label[#1]{#2}%
-\@auxdowrite{\@print{\@deflabeltype}\{#2\}\{\currentlabeltype\}\@print{
+\@auxdowrite{\@print{\@deflabeltype}\{\@getprint{#2}\}\{\currentlabeltype\}\@print{
 }}}
 %%Hum also redefines \enumerate...
 \let\@rt@oldenumerate\enumerate


### PR DESCRIPTION
By using the primitive `\@getprint` the label tag is scanned in a silent mode.