### PR TITLE
[html] No special handling of spaces in display mode

### DIFF
--- a/latexscan.mll
+++ b/latexscan.mll
@@ -1137,7 +1137,7 @@ rule  main = parse
        Dest.put lxm
      else
        begin
-         if !display then
+         if !display && !spaced_display then
            Dest.put_hspace false (Length.Char (String.length lxm))
          else
 	   Dest.put_char ' '
@@ -2783,6 +2783,7 @@ newif_ref "math" in_math ;
 newif_ref "whitepre" whitepre ;
 newif_ref "mmode" in_math ;
 newif_ref "display" display ;
+newif_ref "spaced@display" spaced_display ;
 newif_ref "verbd" displayverb ;
 (* NO NEED AFTER BABEL SUPPORT *)
 (*newif_ref "french" french ;*)

--- a/lexstate.ml
+++ b/lexstate.ml
@@ -120,6 +120,7 @@ type jax = JaxOut | JaxInline | JaxDisplay
   
 (* Status flags *)
 let display = ref false
+and spaced_display = ref false
 and raw_chars = ref false
 and in_math = ref false
 and jaxauto = ref false

--- a/lexstate.mli
+++ b/lexstate.mli
@@ -43,6 +43,7 @@ val effective : alltt -> bool
 
 val raw_chars : bool ref
 val display : bool ref
+val spaced_display : bool ref
 val in_math : bool ref
 val jaxauto : bool ref
 val injaxauto : jax ref


### PR DESCRIPTION
Spaces in display mode are now handled as in math mode: successive spaces yield one space in output.

The old behaviour of outputing one non-breaking space par space in input can be restored by executing
the command `\spaced@displaytrue`.