### PR TITLE
Fix a few pending details in `make -C examples test`

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -46,7 +46,7 @@ install-test:
 	-mkdir -p $(TDIR)
 	cp $(SUITE) $(TDIR)
 	mv $(TDIR)/test.html $(TDIR)/index.html
-	cp *_motif.gif $(TDIR)
+	-cp *_motif.{gif,svg} $(TDIR)
 	cp cart-index.html cart.css cart[0-9][0-9][0-9].html  $(TDIR)
 	cp cart-bis-index.html cart-bis.css cart-bis[0-9][0-9][0-9].html  $(TDIR)
 	cp cart-ter-index.html cart-ter.css cart-ter[0-9][0-9][0-9].html  $(TDIR)

--- a/examples/braces.tex
+++ b/examples/braces.tex
@@ -7,7 +7,7 @@
 \begin{document}
 \[
 \begin{array}{lcc}
-\mbox{Bracket:} & \overbracket{abc\cdots xyz}& \underbracket{abc\cdots xyz}
+\mbox{Bracket:} & \overbracket{abc\cdots xyz}& \underbracket{abc\cdots xyz}\\
 \mbox{ Brace:} & \overbrace{abc\cdots xyz}& \underbrace{abc\cdots xyz}
 \end{array}
 \]

--- a/examples/test.tex
+++ b/examples/test.tex
@@ -13,6 +13,7 @@
 \item The \texttt{listings} \ahref{lis.html}{package}.
 \item Another \texttt{listings} \ahref{lis2.html}{test}.
 \item A \texttt{natbib} \ahref{natbib.html}{test}.
+\item A (very limited) \texttt{mathtools} \ahref{braces.html}{test}.
 \item \texttt{hacha} tests (with footnotes)
 \begin{itemize}
 \item Default behavior: \ahref{cart-index.html}{article},


### PR DESCRIPTION
This includes an unfortunate typo in the mathtools test (a.k.a. examples/braces.tex).

The mathtools package implementation is PR #96.