### PR TITLE
Fix alignment in arrays

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -4,7 +4,9 @@ BIBHVA=bibhva
 HEVEAOPTS=-fix -O -rsz 16
 HACHA=hacha
 EXDIR=$(HOME)/public_html/hevea/examples
-HTML=a.html pat.html suite.html env.html smile.html amstex.html graphics.html graphicx.html verbs.html style-test.html amssymb-test.html boxes.html fancyvrb-test.html
+SUITE=suite.html test.html di.html mp.html lis.html lis2.html\
+ acc.html sym.html natbib.html list.html braces.html
+HTML= $(SUITE) a.html pat.html env.html smile.html amstex.html graphics.html graphicx.html verbs.html style-test.html amssymb-test.html boxes.html fancyvrb-test.html
 HVA=env.hva  pat.hva  smile.hva  st.hva  suite-macros.hva
 STY=suite-macros.sty hevea.sty
 TEX=$(HTML:.html=.tex)
@@ -25,8 +27,6 @@ byte:
 
 dvi: $(DVI)
 
-SUITE=suite.html test.html di.html mp.html lis.html lis2.html\
- acc.html sym.html natbib.html list.html braces.html
 
 sym.html:sym.tex st.hva
 

--- a/examples/random-math.tex
+++ b/examples/random-math.tex
@@ -30,5 +30,20 @@ $$output = \sqrt[5]{\frac{100+int}{100} ~\star input}$$
 
 $$\frac{3}{2} ~\simeq \boxed{\eta \leq \Biggl[\frac{\sqrt{\pi}}{2}\Biggr] \xleftarrow{\theta} ~\Theta} ~\succapprox \cfrac[l]{4}{4+4}$$
 
+In $X \ne Y$ floats right while $Y$ floats left.
+
+\begin{align*}
+\int \frac{x}{e^x-x} dx &\ne \sin \frac{e^\pi}{\text{blah}} \\
+a &\ne b \\
+\frac{1}{x} &\ne \frac{y}{2}
+\end{align*}
+
+\[
+\begin{array}{rcl}
+\int \frac{x}{e^x-x} dx & \ne & \sin \frac{e^\pi}{\text{blah}} \\
+a & \ne & b \\
+\frac{1}{x} & \ne & \frac{y}{2}
+\end{array}
+\]
 
 \end{document}

--- a/examples/suite.tex
+++ b/examples/suite.tex
@@ -485,7 +485,19 @@ A_1 + \frac{A_1}{1} &
 \end{array}
 $$
 
-
+Même idée, mais en \texttt{rcl} et avec des formules plus compliquées.
+Noter que les fractions et vecteur colonnes sont au bon endroit --- poussées à droite à
+gauche, poussées à gauche à droite.
+\[\newcommand{\coucou}[2]{\frac{#2+1}{#1}}
+\begin{array}{rcl}
+\left[ \int \frac{x}{e^x-x} dx \right] &\ne & \sin\left(\frac{e^\pi}{\mbox{blah}}\right) + \sum_{k=1}^{N} \frac{k}{k+1} \\
+\frac{1}{x} & \ne & 0\\
+0 & \ne & \coucou{1}{x}\\
+\begin{array}{c} 1\\ 2\\ 3\\\end{array}
+ & \ne  &
+\begin{array}{c} 3\\ 2\\ 1\\\end{array}
+\end{array}
+\]
 \section{Les tableaux}
 
 \subsection{Environnement définissant un tableau}

--- a/html.ml
+++ b/html.ml
@@ -407,11 +407,11 @@ let open_display () =
   end ;
   do_open_display ()
 
-and open_display_varg a =
+and open_display_varg h v =
   if find_prev_par () then begin
     close_prev_par ()
   end ;
-  do_open_display_varg a
+  do_open_display_varg h v
 
 and close_display () =
   do_close_display () ;

--- a/htmlCommon.ml
+++ b/htmlCommon.ml
@@ -25,7 +25,7 @@ type block =
   | H1 | H2 | H3 | H4 | H5 | H6
   | PRE
   | TABLE | TR | TD
-  | DISPLAY of bool | DFLOW
+  | DISPLAY of bool * string | DFLOW
   | QUOTE | BLOCKQUOTE
   | DIV
   | UL | OL | DL
@@ -35,6 +35,8 @@ type block =
   | P
   | NADA
   | OTHER of string
+
+let default_display = DISPLAY (false,"")
 
 let string_of_block = function
   | H1 -> "h1"
@@ -47,8 +49,14 @@ let string_of_block = function
   | TABLE -> "table"
   | TR -> "tr"
   | TD  -> "td"
-  | DISPLAY false -> "display"
-  | DISPLAY true -> "display (center)"
+  | DISPLAY (center,attr) ->
+      let pp =
+        if center then "display (center)" else "display" in
+      begin
+        match attr with
+        | "" -> pp
+        | _ -> pp ^ ":" ^ attr
+      end
   | DFLOW -> "dflow"
   | QUOTE -> "quote"
   | BLOCKQUOTE -> "blockquote"
@@ -73,8 +81,7 @@ let block_t = Hashtbl.create 17
 let no_opt = false
 
 
-let add b =
-  Hashtbl.add block_t (string_of_block b) b
+let add b = Hashtbl.add block_t (string_of_block b) b
 
 and add_verb s b = Hashtbl.add block_t s b
 
@@ -89,7 +96,7 @@ let () =
   add TABLE ;
   add TR ;
   add TD ;
-  add (DISPLAY false) ;
+  add (default_display) ;
   add QUOTE ;
   add BLOCKQUOTE ;
   add DIV ;
@@ -126,7 +133,7 @@ let check_block_closed opentag closetag =
     not (opentag = AFTER && closetag = GROUP) then
     failclose "html" closetag opentag
 
-let display_arg centering _verbose =
+let display_arg centering attr _verbose =
   let cl =
     if !displayverb then "vdisplay"
     else "display" in
@@ -135,7 +142,10 @@ let display_arg centering _verbose =
       cl^(if  !displayverb then " vdcenter" else " dcenter")
     else cl in
   let arg = "class=\""^cl^"\"" in
-  arg
+  match attr with
+  | "" -> arg
+  | _ -> arg ^ " " ^ attr
+
 
 (* output globals *)
 type t_env = {here : bool ; env : text}
@@ -228,14 +238,14 @@ let pretty_stack s = MyStack.pretty
   (function Normal (s,args,_) -> "["^string_of_block s^"]-{"^args^"}"
     | Freeze _   -> "Freeze") s
 
-let pop_out s = match pop s with
+let unfreeze f s =
+  match f s with
   | Normal (a,b,c) -> a,b,c
   | Freeze _       -> raise PopFreeze
 
-and top_out s = match top s with
-  | Normal (a,b,c) -> a,b,c
-  | Freeze _       -> raise PopFreeze
-
+let pop_out s = unfreeze pop s
+and top_out s = unfreeze top s
+and top2_out s = unfreeze top2 s
 
 let out_stack =
   MyStack.create_init "out_stack" (Normal (NADA,"",!cur_out))
@@ -1144,12 +1154,12 @@ let rec do_open_block insert s args = match s with
         | Some (tag,iargs) -> do_do_open_block tag iargs
         | _ -> ()
       end
-  | DISPLAY centering ->
-      do_open_block insert TABLE (display_arg centering !verbose) ;
+  | DISPLAY (centering,attr) ->
+      do_open_block insert TABLE (display_arg centering attr !verbose) ;
       do_open_block None TR args
   | _  -> begin match insert with
       | Some (tag,iargs) ->
-          if is_list s || s = TABLE || s = P then begin
+            if is_list s || s = TABLE || s = P then begin
             do_do_open_block tag iargs ;
             do_do_open_block s args
           end else begin

--- a/htmlMath.ml
+++ b/htmlMath.ml
@@ -108,12 +108,12 @@ and end_item_display () =
                                                          *                                                       *
 *********************************************************)
 
-let open_display_varg centering varg =
+let open_display_varg centering harg varg =
   if !verbose > 2 then begin
     Printf.fprintf stderr "open_display: "
   end ;
   try_open_display () ;
-  open_block (DISPLAY centering) varg ;
+  open_block (DISPLAY (centering,harg)) varg ;
   open_display_cell "" ;
   open_block DFLOW "" ;
   if !verbose > 2 then begin
@@ -137,12 +137,26 @@ let open_display_varg centering varg =
   end
 *)
 
-let open_display centering = open_display_varg centering "style=\"vertical-align:middle\""
+let open_display centering =
+  open_display_varg centering "" "style=\"vertical-align:middle\""
 
 (* argument force forces the display structure,
    when false, the TABLE/TR/TD may be spared in two situation
    1. No display cell at all (n=0)
    2. One display cell, one empty cell *)
+
+(* At display end, stack is [DFLOW; DISPLAY; ....].
+   Hence to get the attribute of display, one has
+   to look at the second stack element, not the top one. *)
+
+let has_display_attr () =
+  try
+    let ps,_,_ = top2_out out_stack in
+    match ps with
+    | DISPLAY (_,attr) -> attr <> ""
+    | _ -> false
+  with MyStack.Fatal _ -> false
+
 let close_display force =
   if !verbose > 2 then begin
     prerr_flags "=> close_display " ; pretty_stack out_stack ;
@@ -174,7 +188,7 @@ let close_display force =
       begin match ps with
         | DISPLAY _ -> ()
         | _ ->
-            failclose "close_display" ps (DISPLAY false)
+            failclose "close_display" ps default_display
       end;
       try_close_block ps ;
       let old_out = !cur_out in
@@ -183,7 +197,9 @@ let close_display force =
       Out.copy old_out.out !cur_out.out ;
       flags.empty <- false ; flags.blank <- false ;
       !cur_out.pending <- as_envs active pending
-    end else if (n=1 && flags.blank && not force) then begin
+    end else if
+      n=1 && flags.blank && not force && not (has_display_attr ())
+    then begin
       if !verbose > 2 then begin
         prerr_string "No display n=1";
         (Out.debug stderr !cur_out.out);
@@ -195,7 +211,7 @@ let close_display force =
       begin match ps with
         | DISPLAY _ -> ()
         | _ ->
-            failclose "close_display" ps (DISPLAY false)
+            failclose "close_display" ps default_display
       end ;
       try_close_block ps ;
       let old_out = !cur_out in
@@ -212,7 +228,7 @@ let close_display force =
       end;
       flags.empty <- flags.blank ;
       close_flow TD ;
-      close_flow (DISPLAY false)
+      close_flow default_display
     end ;
     try_close_display ()
   end ;
@@ -259,7 +275,7 @@ and force_item_display () = do_item_display true
 let erase_display () =
   erase_block DFLOW ;
   erase_block TD ;
-  erase_block (DISPLAY false);
+  erase_block default_display ;
   try_close_display ()
 
 
@@ -277,11 +293,13 @@ let close_maths display =
 
 (* vertical display *)
 
-let open_vdisplay center display =
+let open_vdisplay center hstyle display =
   if !verbose > 1 then
     prerr_endline "open_vdisplay";
   if not display then  raise (Misc.Fatal ("VDISPLAY in non-display mode"));
-  open_block TABLE (display_arg center !verbose)
+  open_block
+    TABLE
+    (display_arg center hstyle !verbose)
 
 and close_vdisplay () =
   if !verbose > 1 then
@@ -339,7 +357,7 @@ let standard_sup_sub scanner what sup sub display =
 
   if display && (fsub.table_inside || fsup.table_inside) then begin
     force_item_display () ;
-    open_vdisplay false display ;
+    open_vdisplay false "" display ;
     if sup <> "" then begin
       open_vdisplay_row "" "" ;
       clearstyle () ;
@@ -371,7 +389,7 @@ let limit_sup_sub scanner what sup sub display =
     what ()
   else begin
     force_item_display () ;
-    open_vdisplay false display ;
+    open_vdisplay false "" display ;
     open_vdisplay_row "" "style=\"text-align:center\"" ;
     put sup ;
     close_vdisplay_row () ;
@@ -394,7 +412,7 @@ let int_sup_sub something vsize scanner what sup sub display =
     force_item_display ()
   end ;
   if sup <> "" || sub <> "" then begin
-    open_vdisplay false display ;
+    open_vdisplay false "" display ;
     open_vdisplay_row "" "style=\"text-align:left\"" ;
     put sup ;
     close_vdisplay_row () ;
@@ -426,10 +444,10 @@ let insert_vdisplay open_fun =
     let pps,ppargs,ppout = pop_out out_stack  in
     let center =
       match pps with
-        | DISPLAY b -> b
-        | _ -> failclose "insert_vdisplay" pps (DISPLAY false) in
+        | DISPLAY (b,_) -> b
+        | _ -> failclose "insert_vdisplay" pps default_display in
     let new_out = create_status_from_scratch false [] in
-    push_out out_stack (DISPLAY false,ppargs,new_out) ;
+    push_out out_stack (default_display,ppargs,new_out) ;
     push_out out_stack (ps,pargs,pout) ;
     push_out out_stack (bs,bargs,bout) ;
     close_display false ;
@@ -459,10 +477,10 @@ let line_in_vdisplay_row () =
   force_block TD "" ;
   force_block TR ""
 
-let over _lexbuf =
+let over  _lexbuf =
   let mods = insert_vdisplay
     (fun center ->
-      open_vdisplay center true ;
+      open_vdisplay center "" true ;
       open_vdisplay_row "" "style=\"text-align:center\"") in
   close_vdisplay_row () ;
   line_in_vdisplay_row () ;

--- a/latexscan.mll
+++ b/latexscan.mll
@@ -116,36 +116,6 @@ let inc_size i =
   Dest.open_mod (Font new_size)
 ;;
 
-(* Horizontal display *)
-let pre_format = ref None
-
-let top_open_display () =
-  if !display then begin
-    if !verbose > 1 then
-       prerr_endline "open display" ;
-    match !pre_format with
-    | Some (Tabular.Align {Tabular.vert=s})   ->
-        Dest.open_display_varg (sprintf "style=\"vertical-align:%s\"" s)
-    | _ ->
-        Dest.open_display ()        
-  end
-
-and top_item_display () =
-  if !display then begin
-    Dest.item_display ()
-  end
-
-and top_force_item_display () =
-  if !display then begin
-    Dest.force_item_display ()
-  end
-;;
-
-let top_close_display () =
-  if !display then begin
-    Dest.close_display ()
-  end
-
 
 (* Latex environment stuff *)
 
@@ -239,7 +209,11 @@ and hot_all s =
 
 type array_type = {math : bool ; border : bool}
 type in_table = Table of array_type | NoTable | Tabbing
-;;
+
+let is_math_table = function
+  | Table {math; _} -> math
+  | _ -> false
+
 
 let cur_format = ref [||]
 and stack_format = MyStack.create "stack_format"
@@ -300,6 +274,78 @@ and restore_array_state () =
   end  
 ;;
 
+(* Horizontal display *)
+let pre_format = ref None
+
+let default_format =
+  Tabular.Align
+    {Tabular.hor="left" ; vert = "" ; wrap = false ;
+      pre = "" ; post = "" ; width = Length.Default}
+;;
+
+let get_col format i =
+  let r =
+    if i >= Array.length format+1 then
+      raise (Misc.ScanError ("This array/tabular column has no specification"))
+    else if i = Array.length format then default_format
+    else format.(i) in
+  if !verbose > 2 then begin
+   fprintf stderr "get_col : %d: " i ;
+   prerr_endline (Tabular.pretty_format r) ;
+   prerr_string " <- " ;
+   Tabular.pretty_formats format ;
+   prerr_newline ()
+  end ;
+  r
+;;
+
+let to_style = function
+  | None -> ""
+  | Some s -> Printf.sprintf "style=\"%s\"" s
+
+let do_get_hstyle in_table =
+  if is_math_table in_table then
+    match get_col !cur_format !cur_col with
+    | Tabular.Align {Tabular.hor=("right"|"left" as s);_}
+        -> Some (Printf.sprintf "float:%s" s)
+    | _ -> None
+  else None
+
+let get_hstyle () = do_get_hstyle !in_table
+
+let top_open_display () =
+  if !display then begin
+    if !verbose > 1 then
+       prerr_endline "open display" ;
+    let hstyle = get_hstyle () in
+    let vstyle =
+      match !pre_format with
+      |  Some (Tabular.Align {Tabular.vert=s})   ->
+          Some (Printf.sprintf "vertical-align:%s" s)
+      | _ -> None in
+    match hstyle,vstyle with
+    | None,None ->  Dest.open_display ()
+    | _,_ ->
+        Dest.open_display_varg
+         (to_style hstyle) (to_style vstyle)
+  end
+
+and top_item_display () =
+  if !display then begin
+    Dest.item_display ()
+  end
+
+and top_force_item_display () =
+  if !display then begin
+    Dest.force_item_display ()
+  end
+;;
+
+let top_close_display () =
+  if !display then begin
+    Dest.close_display ()
+  end
+
 let top_open_block block args =
   push stack_table !in_table ;
   in_table := NoTable ;
@@ -314,7 +360,7 @@ let top_open_block block args =
   | "display" ->
       push stack_display !display ;
       display := true ;
-      Dest.open_display_varg args
+      Dest.open_display_varg "" args ;
   | "span@inline@block" ->
       Dest.open_block ~force_inline:true "span" args
   | "table" ->
@@ -462,13 +508,6 @@ let get_this_string main s = get_this_arg main (string_to_arg s)
 let more_buff = Out.create_buff ()
 ;;
 
-let default_format =
-  Tabular.Align
-    {Tabular.hor="left" ; vert = "" ; wrap = false ;
-      pre = "" ; post = "" ; width = Length.Default}
-;;
-
-
 let is_table = function
   | Table _ -> true
   | _       -> false
@@ -515,21 +554,6 @@ and as_post = function
   | f -> raise (Misc.Fatal ("as_post "^Tabular.pretty_format f))
 ;;
 
-let get_col format i =
-  let r = 
-    if i >= Array.length format+1 then
-      raise (Misc.ScanError ("This array/tabular column has no specification"))
-    else if i = Array.length format then default_format
-    else format.(i) in
-  if !verbose > 2 then begin
-   fprintf stderr "get_col : %d: " i ;
-   prerr_endline (Tabular.pretty_format r) ;
-   prerr_string " <- " ;
-   Tabular.pretty_formats format ;
-   prerr_newline ()
-  end ;
-  r
-;;
 
 (* Paragraph breaks are different in tables *)
 let par_val t =
@@ -2253,11 +2277,11 @@ def_code "\\right"
     else expand_command "\\textright" lexbuf)
 ;;
 
-
 def_code "\\over"
    (fun lexbuf ->
-     if !display then  Dest.over lexbuf
-     else Dest.put_char '/' ;
+     if !display then begin
+       Dest.over lexbuf
+     end else Dest.put_char '/' ;
      ignore (skip_blanks lexbuf))
 ;;
 

--- a/mathML.ml
+++ b/mathML.ml
@@ -117,7 +117,7 @@ and close_display () =
     prerr_flags ("<= close_display")
 ;;
 
-let open_display_varg _ = open_display ()
+let open_display_varg _ _ = open_display ()
 
   
 let do_item_display _force =

--- a/myStack.mli
+++ b/myStack.mli
@@ -22,6 +22,9 @@ val pop : 'a t -> 'a
 val top : 'a t -> 'a
 val top2 : 'a t -> 'a
 val pretty : ('a -> string) -> 'a t -> unit
+
+
+
 val length : 'a t -> int
 val empty : 'a t -> bool
 val rev : 'a t -> unit

--- a/outManager.mli
+++ b/outManager.mli
@@ -36,7 +36,7 @@ val insert_attr : string -> string -> unit
 
 val open_maths : bool -> unit
 val close_maths : bool -> unit
-val open_display_varg : string -> unit
+val open_display_varg : string -> string -> unit
 val open_display : unit -> unit
 val close_display : unit -> unit
 val item_display : unit -> unit

--- a/text.ml
+++ b/text.ml
@@ -1829,7 +1829,7 @@ let open_display _ =
   open_cell_group ();
 ;;
 
-let open_display_varg _ = open_display ""
+let open_display_varg _ _ = open_display ""
 
 let close_display () =
   if not (flush_freeze ()) then begin
@@ -2048,7 +2048,7 @@ let insert_vdisplay open_fun =
 let addvsize x = flags.vsize <- flags.vsize + x
 
 let over _ =
-  let _=insert_vdisplay 
+  let _ = insert_vdisplay
       ( fun () -> 
 	begin
 	  open_vdisplay display;


### PR DESCRIPTION
 Inside array cells, the "text-align" attribute with values "left" or "right" are not sufficient to position displays correctly.
    
One has to additionally insert "float" (with value "left" or "right") attributes to the top-level table inside array cells. Most of the time, this table pertains a DISPLAY block.
    
However, as an optimisation this DISPLAY block is not  emitted in case the display flow contains 1 item. This item may itself be a TABLE... As a fix we do not apply the optimisation in array cells whose specification is 'r' or 'l'.

Problem reported by  Michael Palmer.