### PR TITLE
Add meta tags

### DIFF
--- a/doc/activatewinfonts.hva
+++ b/doc/activatewinfonts.hva
@@ -1,3 +1,3 @@
-\newcommand{\newstyle}[2]{}%
+\renewcommand{\newstyle}[2]{}%
 \input{winfonts.hva}%
 \undef\newstyle

--- a/doc/manual.hva
+++ b/doc/manual.hva
@@ -11,8 +11,7 @@
 \newcommand{\myrule}{}
 \newenvironment{htmlout}{\begin{quote}\myrule}{\myrule\end{quote}}
 \newenvironment{multicols}[1]{}{}
-\addto{\@meta}{\@print{<meta name="Author" content="Luc Maranget">}
-}
+\newmeta{name="Author" content="Luc Maranget"}
 \newcommand{\showcolor}[1]{\textcolor{#1}{\texttt{#1}}}
 \renewcommand{\cuttingunit}{part}
 \setcounter{cuttingdepth}{1}

--- a/doc/text.tex
+++ b/doc/text.tex
@@ -45,6 +45,7 @@ Cedex~12. {\tt \mailto{Luc.Maranget@inria.fr}}}}
 \urldef{\ftpbase}{\url}{http://hevea.inria.fr/distri}
 \fi
 \urldef{\httpbase}{\url}{http://hevea.inria.fr/}
+\newmeta{name="viewport" content="width=device-width, initial-scale=1"}
 \def\stylex{padding:1ex;color:navy;border:solid navy;}
 \newstyle{.subsectionex}{\stylex}
 \def\verbstyle{margin:1ex 1ex;padding:1ex;background:\@getstylecolor{paragraph};}%
@@ -4382,6 +4383,19 @@ Note how \verb+\@meta+ is first bound to
 invoked in the new definition of \verb+\@meta+.
 Namely, simply overriding the old definition of \verb+\@meta+ would
 imply not outputting default meta-information.
+
+\comindex{newmeta}
+We provide a simpler and more direct mean to add \verb+meta+ elements into
+the \html{} document preamble: the \verb+\newmeta+ command that
+takes attributes as its argument. In other words a simpler technique for adding the ``Author''  meta-information to the document is as follows:
+\begin{verbatim}
+\newmeta{name="Author" content="Luc Maranget"}
+\end{verbatim}
+In some sense, the command  \verb+\newmeta+ is aware that its argument
+consists of attributes and its definition takes care of issuing verbarim text.
+As a consequence there is no need for using a quoting mecanism as in the
+previous paragraph.
+
 
 \index{"@charset@\texttt{\char92"@charset}}
 The \verb+\@charset+ command holds the value of the (\html) document character

--- a/hevea.sty
+++ b/hevea.sty
@@ -78,6 +78,7 @@
    \colorbox{\@mycolor}{\usebox{\@bgcolorbin}}%
    \end{flushleft}}
 %%% Style sheets macros, defined as no-ops
+\newcommand{\newmeta}[1]{}
 \newcommand{\newstyle}[2]{}
 \newcommand{\addstyle}[1]{}
 \newcommand{\setenvclass}[2]{}

--- a/html/hevea.hva
+++ b/html/hevea.hva
@@ -20,6 +20,9 @@
 \newcommand{\addstyle}[1]{\addtokens{\hevea@css}{#1}}%
 \newcommand{\newstyle}[2]{\addstyle{\@getprint{#1\char123#2\char125\@print{
 }}}}%
+\newtokens{\hevea@meta}%
+\newcommand{\newmeta}[1]{\addtokens{\hevea@meta}{\@print{<meta }\@getprint{#1}\@print{>
+}}}%
 \newif\ifexternalcss\externalcssfalse
 %
 %%Style attributes are normaly set through an indirection.
@@ -289,13 +292,15 @@
 <meta name="generator" content="hevea }%
 \@getprint{\usebox{\@heveaversion}}\@print{">
 }%
+\ife\hevea@meta\else\hevea@meta\fi
+\undef\hevea@meta%
 \ife\hevea@css\else
 \ifexternalcss\loadcssfile{\hva@dump@css}\else
 \@print{<style type="text/css">}
 \hevea@css\@print{</style>
 }\fi\fi
 \ife\css@link\else\css@link\fi
-\undef\hevea@css\undef\newstyle}
+\undef\hevea@css}
 \newenvironment{document}{%
 \@end{document}%
 \@atbegindocument%
@@ -334,7 +339,8 @@
 \cutdef*[\thecuttingdepth]{\cuttingunit}%
 \ife\@hacha@defs\else\@printnostyle{<!--SETENV }\@hacha@defs\@printnostyle{-->
 }\undef\@hacha@defs\fi
-\renewcommand{\addstyle}[1]{\hva@warn{\addstyle{} must be used in document preamble}}%
+\renewcommand{\newstyle}[2]{\hva@warn{\newstyle{} must be used in document preamble}}%
+\renewcommand{\newmeta}[1]{\hva@warn{\newmeta{} must be used in document preamble}}%
 \@open@par%Open first paragraph
 }{%
 \@clearstyle\@footnoteflush{\@footnotelevel}\cutend*\title@flush@hook%


### PR DESCRIPTION
Writing `\newmeta{`*attrs*`}` in the document preamble adds a `meta` element with attributes *attrs* to the HTML header. For instance:
```
\newmeta{name="viewport" content="width=device-width, initial-scale=1"}
```
Adds the following element:
```
<meta name="viewport" content="width=device-width, initial-scale=1">
```
