### PR TITLE
[hevea] Nicer right square bracket delimter for winfonts.hva

### DIFF
--- a/doc/text.tex
+++ b/doc/text.tex
@@ -6434,7 +6434,7 @@ At the moment, loading \texttt{winfonts.hva}
 only changes the rendering
 of \LaTeX{} big delimiters, avoiding the troublesome Unicode entities.
 \ifhevea
-As an example, here are some examples of rendering.
+Here are some examples of rendering:
 $$
 \newcommand{\zyva}[2]
 {\mbox{\ttfamily\string\left\string#1\quad\ldots\quad\string\right\string#2} &

--- a/winfonts.hva
+++ b/winfonts.hva
@@ -48,7 +48,7 @@
 {\setcounter{@c}{(#1)}%
 \@open{table}{class="delimright"}%
 \@hbarcell{\@@@barsz}%
-\@bracell[ \win@right@cell]{\@@vbar[style="height:\arabic{@c}em;"]}%
+\@bracell[ \win@right@cell]{\@@vbar[style="height:\arabic{@c}em;float:right;"]}%
 \@hbarcell{\@@@barsz}%
 \@close{table}}%
 \renewcommand{\csname\delim@name{]}\endcsname}[1]


### PR DESCRIPTION
Have an actual right delimiter for `\right]`, using the `float:right` attribute.